### PR TITLE
Add a 5 sec delay between publishing each crate

### DIFF
--- a/.github/workflows/dasp.yml
+++ b/.github/workflows/dasp.yml
@@ -215,33 +215,53 @@ jobs:
     - name: cargo publish dasp_sample
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_sample/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_frame
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_frame/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_slice
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_slice/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_ring_buffer
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_ring_buffer/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_peak
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_peak/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_rms
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_rms/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_interpolate
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_interpolate/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_window
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_window/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_envelope
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_envelope/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp_signal
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp_signal/Cargo.toml
+    - name: wait for crates.io
+      run: sleep 5
     - name: cargo publish dasp
       continue-on-error: true
       run: cargo publish --token $CRATESIO_TOKEN --manifest-path dasp/Cargo.toml


### PR DESCRIPTION
It seems that we need to introduce a bit of a delay to let crates.io
properly register each package before before publishing its descendents.
Otherwise, they compile so fast that crates.io returns an error saying
that the dependencies don't exist.