### PR TITLE
Revert "Publish dasp 0.11.1"

### DIFF
--- a/dasp/Cargo.toml
+++ b/dasp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dasp"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.11.1"
+version = "0.11.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "../README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]


### PR DESCRIPTION
This reverts RustAudio/dasp#132 - I had forgotten about the rename from `hanning` to `hann` in #128, a breaking change which should not land in the 0.11 version series.

The inclusion of `dasp_graph` within `dasp` will have to wait until version `0.12.0`. In the meantime, `dasp_graph` is published on crates.io as `0.11.0` and can be used directly.