### PR TITLE
Impl Step for Phase

### DIFF
--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -1915,6 +1915,15 @@ where
     }
 }
 
+impl<S> Step for Phase<S>
+where
+    S: Step,
+{
+    fn step(&mut self) -> f64 {
+        self.step.step()
+    }
+}
+
 impl<S> Phase<S>
 where
     S: Step,


### PR DESCRIPTION
I'm currently implementing [PolyBLEP](http://www.martin-finke.de/blog/articles/audio-plugins-018-polyblep-oscillator/) oscillators using the `Signal` trait. One problem that occurred is that I need a current `step` and `phase` at the same time. But as step is private in `Phase` it is not possible so get the current step.

What is the most ergonomic way to implement this? In this PR I just implemented `Step` for `Phase`, so that one can just call `step` on any `Phase` to get the internal step value.