### PR TITLE
Fix sinc interpolator

### DIFF
--- a/dasp_interpolate/src/sinc/mod.rs
+++ b/dasp_interpolate/src/sinc/mod.rs
@@ -92,8 +92,8 @@ where
             v = {
                 let a = PI * (phil + n as f64);
                 let first = if a == 0.0 { 1.0 } else { sin(a) / a };
-                let second = 0.5 + 0.5 * cos(a / (phil + max_depth as f64));
-                v.zip_map(self.frames[nr - n], |vs, r_lag| {
+                let second = 0.5 + 0.5 * cos(a / depth as f64);
+                v.zip_map(self.frames[nl - n], |vs, r_lag| {
                     vs.add_amp(
                         (first * second * r_lag.to_sample::<f64>())
                             .to_sample::<<Self::Frame as Frame>::Sample>()
@@ -104,8 +104,8 @@ where
 
             let a = PI * (phir + n as f64);
             let first = if a == 0.0 { 1.0 } else { sin(a) / a };
-            let second = 0.5 + 0.5 * cos(a / (phir + max_depth as f64));
-            v.zip_map(self.frames[nl + n], |vs, r_lag| {
+            let second = 0.5 + 0.5 * cos(a / depth as f64);
+            v.zip_map(self.frames[nr + n], |vs, r_lag| {
                 vs.add_amp(
                     (first * second * r_lag.to_sample::<f64>())
                         .to_sample::<<Self::Frame as Frame>::Sample>()


### PR DESCRIPTION
The resampling example didn't sound great (there were audible artifacts), so I did some investigation.

Trying to downsample an impulse (prefiltered to rule out aliasing) results in the following spectrums:

![image](https://user-images.githubusercontent.com/7241014/100141179-ab607a00-2e9a-11eb-8778-ada856dcd25f.png)
(Audacity's resampler on the left; dasp sinc on the right)

Upsampling an impulse looks rough:
![image](https://user-images.githubusercontent.com/7241014/100141607-5f620500-2e9b-11eb-8684-2917597c3296.png)

That seems wrong.

Turns out there was an indexing error in [the implementation](https://github.com/RustAudio/dasp/blob/f05a703d247bb504d7e812b51e95f3765d9c5e94/dasp_interpolate/src/sinc/mod.rs#L96):
```rust
// Left side
v.zip_map(self.frames[nr - n], |vs, r_lag| {
// Right side
v.zip_map(self.frames[nl + n], |vs, r_lag| {
```
`nl` is the index of the first sample to the left, and `nr` is the first sample to the right, so these are clearly the wrong way around.

The upsampled impulse looks clean now:
![image](https://user-images.githubusercontent.com/7241014/100141753-8e787680-2e9b-11eb-82e1-d4c879df42e6.png)

---

The example still doesn't sound great even when prefiltered. I disabled the sinc and left only the Hann window (`let second`) active. This is the spectrum of an impulse being upsampled from 10kHz to 80kHz, ring buffer size still 100:
![image](https://user-images.githubusercontent.com/7241014/100144322-4c513400-2e9f-11eb-8f02-6e4ff306d67b.png)
There is some content in the high end which shouldn't be there.

Here the issue was in the scale of the window function:
```rust
let second = 0.5 + 0.5 * cos(a / (phil + max_depth as f64));
```
The scale should remain constant and not be affected by `phil`/`phir`, or the amount of samples in the ring buffer. **EDIT:** The amount of samples should affect it, as long as the midpoint moves in relation to x like it does now. Not sure if that's ideal though.

Changing this to
```rust
let second = 0.5 + 0.5 * cos(a / depth as f64);
```
improves things:
![image](https://user-images.githubusercontent.com/7241014/100145022-5c1d4800-2ea0-11eb-9645-66baab2e7cd2.png)
(note that absolute amplitude is different mainly because I selected a different size interval for analysis)

The example, when prefiltered, now sounds much better!

A couple things I didn't implement yet but could be considered:
 - When downsampling, aliasing occurs, so the signal needs to be filtered in advance. But since we're using sinc interpolation, we can also filter the signal at the same time by adjusting the sinc's frequency.
 - The code could use a little tidying in general. Separating the left and right sides shouldn't be necessary, and it would make more sense to index the ring buffer by 0..N instead of 1..=N.
 - Tests?