### PR TITLE
Improve mutable access to `Sample`s in `Frame`

### DIFF
--- a/dasp_frame/src/lib.rs
+++ b/dasp_frame/src/lib.rs
@@ -84,6 +84,9 @@ pub trait Frame: Copy + Clone + PartialEq {
     /// Yields a reference to the `Sample` of the channel at the given index if there is one.
     fn channel(&self, idx: usize) -> Option<&Self::Sample>;
 
+    /// Like [`channel()`], but yields a mutable reference instead.
+    fn channel_mut(&mut self, idx: usize) -> Option<&mut Self::Sample>;
+
     /// Returns a pointer to the sample of the channel at the given index, without doing bounds
     /// checking.
     ///
@@ -292,6 +295,11 @@ macro_rules! impl_frame_for_fixed_size_array {
                 }
 
                 #[inline]
+                fn channel_mut(&mut self, idx: usize) -> Option<&mut Self::Sample> {
+                    self.get_mut(idx)
+                }
+
+                #[inline]
                 fn from_fn<F>(mut from: F) -> Self
                 where
                     F: FnMut(usize) -> S,
@@ -447,6 +455,15 @@ macro_rules! impl_frame_for_sample {
 
                 #[inline]
                 fn channel(&self, idx: usize) -> Option<&Self::Sample> {
+                    if idx == 0 {
+                        Some(self)
+                    } else {
+                        None
+                    }
+                }
+
+                #[inline]
+                fn channel_mut(&mut self, idx: usize) -> Option<&mut Self::Sample> {
                     if idx == 0 {
                         Some(self)
                     } else {

--- a/dasp_frame/src/lib.rs
+++ b/dasp_frame/src/lib.rs
@@ -5,6 +5,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::iter::DoubleEndedIterator;
+
 use dasp_sample::Sample;
 
 /// Represents one sample from each channel at a single discrete instance in time within a
@@ -662,6 +664,13 @@ impl<'a, F: Frame> ExactSizeIterator for ChannelsRef<'a, F> {
     }
 }
 
+impl<'a, F: Frame> DoubleEndedIterator for ChannelsRef<'a, F> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+}
+
 impl<'a, F: Frame> Iterator for ChannelsMut<'a, F> {
     type Item = &'a mut F::Sample;
 
@@ -680,5 +689,12 @@ impl<'a, F: Frame> ExactSizeIterator for ChannelsMut<'a, F> {
     #[inline]
     fn len(&self) -> usize {
         self.0.len()
+    }
+}
+
+impl<'a, F: Frame> DoubleEndedIterator for ChannelsMut<'a, F> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
     }
 }

--- a/dasp_frame/src/lib.rs
+++ b/dasp_frame/src/lib.rs
@@ -272,14 +272,10 @@ pub struct Channels<F> {
 
 /// An iterator that yields the sample for each channel in the frame by reference.
 #[derive(Clone)]
-pub struct ChannelsRef<'a, F: Frame> {
-    iter: std::slice::Iter<'a, F::Sample>,
-}
+pub struct ChannelsRef<'a, F: Frame>(std::slice::Iter<'a, F::Sample>);
 
 /// Like [`ChannelsRef`], but yields mutable references instead.
-pub struct ChannelsMut<'a, F: Frame> {
-    iter: std::slice::IterMut<'a, F::Sample>,
-}
+pub struct ChannelsMut<'a, F: Frame>(std::slice::IterMut<'a, F::Sample>);
 
 macro_rules! impl_frame_for_fixed_size_array {
     ($($NChan:ident $N:expr, [$($idx:expr)*],)*) => {
@@ -311,16 +307,12 @@ macro_rules! impl_frame_for_fixed_size_array {
 
                 #[inline]
                 fn channels_ref(&self) -> ChannelsRef<'_, Self> {
-                    ChannelsRef {
-                        iter: self.iter()
-                    }
+                    ChannelsRef(self.iter())
                 }
 
                 #[inline]
                 fn channels_mut(&mut self) -> ChannelsMut<'_, Self> {
-                    ChannelsMut {
-                        iter: self.iter_mut()
-                    }
+                    ChannelsMut(self.iter_mut())
                 }
 
                 #[inline]
@@ -494,16 +486,12 @@ macro_rules! impl_frame_for_sample {
 
                 #[inline]
                 fn channels_ref(&self) -> ChannelsRef<'_, Self> {
-                    ChannelsRef {
-                        iter: std::slice::from_ref(self).iter()
-                    }
+                    ChannelsRef(std::slice::from_ref(self).iter())
                 }
 
                 #[inline]
                 fn channels_mut(&mut self) -> ChannelsMut<'_, Self> {
-                    ChannelsMut {
-                        iter: std::slice::from_mut(self).iter_mut()
-                    }
+                    ChannelsMut(std::slice::from_mut(self).iter_mut())
                 }
 
                 #[inline]
@@ -658,19 +646,19 @@ impl<'a, F: Frame> Iterator for ChannelsRef<'a, F> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.0.next()
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        self.0.size_hint()
     }
 }
 
 impl<'a, F: Frame> ExactSizeIterator for ChannelsRef<'a, F> {
     #[inline]
     fn len(&self) -> usize {
-        self.iter.len()
+        self.0.len()
     }
 }
 
@@ -679,18 +667,18 @@ impl<'a, F: Frame> Iterator for ChannelsMut<'a, F> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.0.next()
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        self.0.size_hint()
     }
 }
 
 impl<'a, F: Frame> ExactSizeIterator for ChannelsMut<'a, F> {
     #[inline]
     fn len(&self) -> usize {
-        self.iter.len()
+        self.0.len()
     }
 }

--- a/dasp_frame/src/lib.rs
+++ b/dasp_frame/src/lib.rs
@@ -87,6 +87,22 @@ pub trait Frame: Copy + Clone + PartialEq {
     fn channels_ref(&self) -> ChannelsRef<'_, Self>;
 
     /// Like [`channels_ref()`], but yields mutable references instead.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use dasp_frame::Frame;
+    ///
+    /// fn main() {
+    ///     let mut foo = [1000i32, 2000, 3000];
+    ///     let mut offset = 100i32;
+    ///     for f in foo.channels_mut() {
+    ///         *f = *f + offset;
+    ///         offset += 100;
+    ///     }
+    ///     assert_eq!(foo, [1100i32, 2200, 3300]);
+    /// }
+    /// ```
     fn channels_mut(&mut self) -> ChannelsMut<'_, Self>;
 
     /// Yields a reference to the `Sample` of the channel at the given index if there is one.

--- a/dasp_frame/src/lib.rs
+++ b/dasp_frame/src/lib.rs
@@ -95,6 +95,9 @@ pub trait Frame: Copy + Clone + PartialEq {
     /// at *compile-time*.
     unsafe fn channel_unchecked(&self, idx: usize) -> &Self::Sample;
 
+    /// Like [`channel_unchecked()`], but yields a mutable reference instead.
+    unsafe fn channel_unchecked_mut(&mut self, idx: usize) -> &mut Self::Sample;
+
     /// Applies the given function to each sample in the `Frame` in channel order and returns the
     /// result as a new `Frame`.
     ///
@@ -326,6 +329,11 @@ macro_rules! impl_frame_for_fixed_size_array {
                     self.get_unchecked(idx)
                 }
 
+                #[inline(always)]
+                unsafe fn channel_unchecked_mut(&mut self, idx: usize) -> &mut Self::Sample {
+                    self.get_unchecked_mut(idx)
+                }
+
                 #[inline]
                 fn to_signed_frame(self) -> Self::Signed {
                     self.map(|s| s.to_sample())
@@ -489,6 +497,11 @@ macro_rules! impl_frame_for_sample {
 
                 #[inline(always)]
                 unsafe fn channel_unchecked(&self, _idx: usize) -> &Self::Sample {
+                    self
+                }
+
+                #[inline(always)]
+                unsafe fn channel_unchecked_mut(&mut self, _idx: usize) -> &mut Self::Sample {
                     self
                 }
 

--- a/dasp_frame/src/lib.rs
+++ b/dasp_frame/src/lib.rs
@@ -274,10 +274,10 @@ pub struct Channels<F> {
 
 /// An iterator that yields the sample for each channel in the frame by reference.
 #[derive(Clone)]
-pub struct ChannelsRef<'a, F: Frame>(std::slice::Iter<'a, F::Sample>);
+pub struct ChannelsRef<'a, F: Frame>(core::slice::Iter<'a, F::Sample>);
 
 /// Like [`ChannelsRef`], but yields mutable references instead.
-pub struct ChannelsMut<'a, F: Frame>(std::slice::IterMut<'a, F::Sample>);
+pub struct ChannelsMut<'a, F: Frame>(core::slice::IterMut<'a, F::Sample>);
 
 macro_rules! impl_frame_for_fixed_size_array {
     ($($NChan:ident $N:expr, [$($idx:expr)*],)*) => {
@@ -488,12 +488,12 @@ macro_rules! impl_frame_for_sample {
 
                 #[inline]
                 fn channels_ref(&self) -> ChannelsRef<'_, Self> {
-                    ChannelsRef(std::slice::from_ref(self).iter())
+                    ChannelsRef(core::slice::from_ref(self).iter())
                 }
 
                 #[inline]
                 fn channels_mut(&mut self) -> ChannelsMut<'_, Self> {
-                    ChannelsMut(std::slice::from_mut(self).iter_mut())
+                    ChannelsMut(core::slice::from_mut(self).iter_mut())
                 }
 
                 #[inline]


### PR DESCRIPTION
Closes #146.

Changes:
* Add method: `Frame::channel_mut`
* Add method: `Frame::channel_unchecked_mut`
* Add method: `Frame::channels_ref`
* Add method: `Frame::channels_mut`
* Add iterator type: `ChannelsRef`
* Add iterator type: `ChannelsMut`