### PR TITLE
#145

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "dasp",
     "dasp_envelope",
+    "dasp_filter",
     "dasp_frame",
     "dasp_graph",
     "dasp_interpolate",

--- a/dasp/Cargo.toml
+++ b/dasp/Cargo.toml
@@ -49,6 +49,7 @@ all-no-std = [
     "signal-boxed",
     "signal-bus",
     "signal-envelope",
+    "signal-filter",
     "signal-rms",
     "signal-window",
     "signal-window-hann",
@@ -94,6 +95,7 @@ signal = ["dasp_signal"]
 signal-boxed = ["dasp_signal/boxed"]
 signal-bus = ["dasp_signal/bus"]
 signal-envelope = ["dasp_signal/envelope", "envelope"]
+signal-filter = ["dasp_signal/filter", "filter"]
 signal-rms = ["dasp_signal/rms", "rms"]
 signal-window = ["dasp_signal/window", "window"]
 signal-window-hann = ["dasp_signal/window-hann", "window-hann"]

--- a/dasp/Cargo.toml
+++ b/dasp/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 dasp_envelope = { version = "0.11", path = "../dasp_envelope", default-features = false, optional = true }
+dasp_filter = { version = "0.11", path = "../dasp_filter", default-features = false, optional = true }
 dasp_frame = { version = "0.11", path = "../dasp_frame", default-features = false }
 dasp_graph = { version = "0.11", path = "../dasp_graph", default-features = false, optional = true }
 dasp_interpolate = { version = "0.11", path = "../dasp_interpolate", default-features = false, optional = true }
@@ -36,6 +37,7 @@ all-no-std = [
     "envelope",
     "envelope-peak",
     "envelope-rms",
+    "filter",
     "interpolate",
     "interpolate-floor",
     "interpolate-linear",
@@ -59,6 +61,7 @@ all-no-std = [
 ]
 std = [
     "dasp_envelope/std",
+    "dasp_filter/std",
     "dasp_frame/std",
     "dasp_interpolate/std",
     "dasp_peak/std",
@@ -72,6 +75,7 @@ std = [
 envelope = ["dasp_envelope"]
 envelope-peak = ["dasp_envelope/peak"]
 envelope-rms = ["dasp_envelope/rms"]
+filter = ["dasp_filter"]
 graph = ["dasp_graph"]
 graph-all-nodes = ["dasp_graph/all-nodes"]
 graph-node-boxed = ["dasp_graph/node-boxed"]

--- a/dasp_filter/Cargo.toml
+++ b/dasp_filter/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "dasp_filter"
+description = "Filters for digital audio signals."
+version = "0.11.0"
+authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "Mark LeMoine <linclelinkpart5@gmail.com>"]
+readme = "../README.md"
+keywords = ["dsp", "filter", "biquad"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rustaudio/dasp.git"
+homepage = "https://github.com/rustaudio/dasp"
+edition = "2018"
+
+[dependencies]
+dasp_frame = { version = "0.11", path = "../dasp_frame", default-features = false }
+dasp_sample = { version = "0.11", path = "../dasp_sample", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "dasp_frame/std",
+    "dasp_sample/std",
+]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -1,0 +1,3 @@
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -35,3 +35,17 @@ where
     m1: F,
     m2: F,
 }
+
+impl<S, F> Biquad<S, F>
+where
+    S: FloatSample,
+    F: Frame<Sample = S>,
+{
+    pub fn new(coeff: Coefficients<S>) -> Self {
+        Self {
+            coeff,
+            m1: F::EQUILIBRIUM,
+            m2: F::EQUILIBRIUM,
+        }
+    }
+}

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -105,3 +105,14 @@ where
         output.map(FromSample::from_sample_)
     }
 }
+
+impl<F> From<Coefficients<F::Sample>> for Biquad<F>
+where
+    F: Frame,
+    F::Sample: FloatSample,
+{
+    // Same as `new()`, but adding this for the blanket `Into` impl.
+    fn from(coeff: Coefficients<F::Sample>) -> Self {
+        Self::new(coeff)
+    }
+}

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 
+use dasp_frame::Frame;
 use dasp_sample::FloatSample;
 
 /// Coefficients for a digital biquad filter.
@@ -22,4 +23,15 @@ where
     pub a2: S,
 }
 
+/// An implementation of a digital biquad filter.
+pub struct Biquad<S, F>
+where
+    S: FloatSample,
+    F: Frame<Sample = S>,
+{
+    coeff: Coefficients<S>,
 
+    // Since biquad filters are second-order, we require two historical buffers.
+    m1: F,
+    m2: F,
+}

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -51,6 +51,8 @@ where
         }
     }
 
+    /// Performs a single iteration of this filter, calculating a new filtered
+    /// `Frame` from an input `Frame`.
     pub fn apply<I>(&mut self, input: I) -> I
     where
         I: Frame<NumChannels = F::NumChannels>,

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -1,3 +1,25 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
+
+use dasp_sample::FloatSample;
+
+/// Coefficients for a digital biquad filter.
+/// It is assumed that the `a0` coefficient is always normalized to 1.0,
+/// and thus not included.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Coefficients<S>
+where
+    S: FloatSample,
+{
+    // Numerator coefficients.
+    pub b0: S,
+    pub b1: S,
+    pub b2: S,
+
+    // Denominator coefficients.
+    pub a1: S,
+    pub a2: S,
+}
+
+

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -13,14 +13,14 @@ pub struct Coefficients<S>
 where
     S: FloatSample,
 {
-    // Numerator coefficients.
-    pub b0: S,
-    pub b1: S,
-    pub b2: S,
+    // Numerator coefficients (normally b0, b1, b2).
+    pub n0: S,
+    pub n1: S,
+    pub n2: S,
 
-    // Denominator coefficients.
-    pub a1: S,
-    pub a2: S,
+    // Denominator coefficients (normally a1, a2).
+    pub d1: S,
+    pub d2: S,
 }
 
 /// An implementation of a digital biquad filter, using the Direct Form 2
@@ -30,12 +30,12 @@ where
     F: Frame,
     F::Sample: FloatSample,
 {
-    coeff: Coefficients<F::Sample>,
+    pub coeff: Coefficients<F::Sample>,
 
     // Since biquad filters are second-order, we require two historical buffers.
     // This state is updated each time the filter is applied to a `Frame`.
-    m0: F,
-    m1: F,
+    t0: F,
+    t1: F,
 }
 
 impl<F> Biquad<F>
@@ -46,8 +46,8 @@ where
     pub fn new(coeff: Coefficients<F::Sample>) -> Self {
         Self {
             coeff,
-            m0: F::EQUILIBRIUM,
-            m1: F::EQUILIBRIUM,
+            t0: F::EQUILIBRIUM,
+            t1: F::EQUILIBRIUM,
         }
     }
 
@@ -62,21 +62,21 @@ where
         let input: F = input.map(ToSample::to_sample_);
 
         // Calculate scaled inputs.
-        let input_by_b0 = input.scale_amp(self.coeff.b0);
-        let input_by_b1 = input.scale_amp(self.coeff.b1);
-        let input_by_b2 = input.scale_amp(self.coeff.b2);
+        let input_by_n0 = input.scale_amp(self.coeff.n0);
+        let input_by_n1 = input.scale_amp(self.coeff.n1);
+        let input_by_n2 = input.scale_amp(self.coeff.n2);
 
         // This is the new filtered `Frame`.
-        let output: F = self.m0.add_amp(input_by_b0);
+        let output: F = self.t0.add_amp(input_by_n0);
 
         // Calculate scaled outputs.
         // NOTE: Negative signs on the scaling factors for these.
-        let output_by_neg_a1 = output.scale_amp(-self.coeff.a1);
-        let output_by_neg_a2 = output.scale_amp(-self.coeff.a2);
+        let output_by_neg_d1 = output.scale_amp(-self.coeff.d1);
+        let output_by_neg_d2 = output.scale_amp(-self.coeff.d2);
 
         // Update buffers.
-        self.m0 = self.m1.add_amp(input_by_b1).add_amp(output_by_neg_a1);
-        self.m1 = input_by_b2.add_amp(output_by_neg_a2);
+        self.t0 = self.t1.add_amp(input_by_n1).add_amp(output_by_neg_d1);
+        self.t1 = input_by_n2.add_amp(output_by_neg_d2);
 
         // Convert back into the original `Frame` format.
         output.map(FromSample::from_sample_)

--- a/dasp_filter/src/lib.rs
+++ b/dasp_filter/src/lib.rs
@@ -13,14 +13,14 @@ pub struct Coefficients<S>
 where
     S: FloatSample,
 {
-    // Numerator coefficients (normally b0, b1, b2).
-    pub n0: S,
-    pub n1: S,
-    pub n2: S,
+    // Transfer function numerator coefficients.
+    pub b0: S,
+    pub b1: S,
+    pub b2: S,
 
-    // Denominator coefficients (normally a1, a2).
-    pub d1: S,
-    pub d2: S,
+    // Transfer function denominator coefficients.
+    pub a1: S,
+    pub a2: S,
 }
 
 /// An implementation of a digital biquad filter, using the Direct Form 2
@@ -53,6 +53,29 @@ where
 
     /// Performs a single iteration of this filter, calculating a new filtered
     /// `Frame` from an input `Frame`.
+    ///
+    /// ```rust
+    /// use dasp_filter::{Coefficients, Biquad};
+    ///
+    /// fn main() {
+    ///     // Notch boost filter.
+    ///     let co = Coefficients {
+    ///         b0: 1.0469127398708575f64,
+    ///         b1: -0.27732002669854483,
+    ///         b2: 0.8588151488168104,
+    ///         a1: -0.27732002669854483,
+    ///         a2: 0.9057278886876682,
+    ///     };
+    ///
+    ///     // Note that this type argument defines the format of the temporary
+    ///     // values, as well as the number of channels required for input
+    ///     // `Frame`s.
+    ///     let mut b = Biquad::<[f64; 2]>::new(co);
+    ///
+    ///     assert_eq!(b.apply([32i8, -64]), [33, -67]);
+    ///     assert_eq!(b.apply([0.1f32, -0.3]), [0.107943736, -0.32057875]);
+    /// }
+    /// ```
     pub fn apply<I>(&mut self, input: I) -> I
     where
         I: Frame<NumChannels = F::NumChannels>,
@@ -62,21 +85,21 @@ where
         let input: F = input.map(ToSample::to_sample_);
 
         // Calculate scaled inputs.
-        let input_by_n0 = input.scale_amp(self.coeff.n0);
-        let input_by_n1 = input.scale_amp(self.coeff.n1);
-        let input_by_n2 = input.scale_amp(self.coeff.n2);
+        let input_by_b0 = input.scale_amp(self.coeff.b0);
+        let input_by_b1 = input.scale_amp(self.coeff.b1);
+        let input_by_b2 = input.scale_amp(self.coeff.b2);
 
         // This is the new filtered `Frame`.
-        let output: F = self.t0.add_amp(input_by_n0);
+        let output: F = self.t0.add_amp(input_by_b0);
 
         // Calculate scaled outputs.
         // NOTE: Negative signs on the scaling factors for these.
-        let output_by_neg_d1 = output.scale_amp(-self.coeff.d1);
-        let output_by_neg_d2 = output.scale_amp(-self.coeff.d2);
+        let output_by_neg_a1 = output.scale_amp(-self.coeff.a1);
+        let output_by_neg_a2 = output.scale_amp(-self.coeff.a2);
 
         // Update buffers.
-        self.t0 = self.t1.add_amp(input_by_n1).add_amp(output_by_neg_d1);
-        self.t1 = input_by_n2.add_amp(output_by_neg_d2);
+        self.t0 = self.t1.add_amp(input_by_b1).add_amp(output_by_neg_a1);
+        self.t1 = input_by_b2.add_amp(output_by_neg_a2);
 
         // Convert back into the original `Frame` format.
         output.map(FromSample::from_sample_)

--- a/dasp_signal/Cargo.toml
+++ b/dasp_signal/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 dasp_envelope = { version = "0.11", path = "../dasp_envelope", default-features = false, optional = true }
+dasp_filter = { version = "0.11", path = "../dasp_filter", default-features = false, optional = true }
 dasp_frame = { version = "0.11", path = "../dasp_frame", default-features = false }
 dasp_interpolate = { version = "0.11", path = "../dasp_interpolate", default-features = false }
 dasp_peak = { version = "0.11", path = "../dasp_peak", default-features = false }
@@ -32,6 +33,7 @@ all-no-std = [
     "boxed",
     "bus",
     "envelope",
+    "filter",
     "rms",
     "window",
     "window-hann",
@@ -39,6 +41,7 @@ all-no-std = [
 ]
 std = [
     "dasp_envelope/std",
+    "dasp_filter/std",
     "dasp_frame/std",
     "dasp_interpolate/std",
     "dasp_peak/std",
@@ -50,6 +53,7 @@ std = [
 boxed = []
 bus = []
 envelope = ["dasp_envelope"]
+filter = ["dasp_filter"]
 rms = ["dasp_rms"]
 window = ["dasp_window"]
 window-hann = ["dasp_window/hann"]

--- a/dasp_signal/src/filter.rs
+++ b/dasp_signal/src/filter.rs
@@ -46,3 +46,21 @@ where
     signal: S,
     biquad: filter::Biquad<<S::Frame as Frame>::Float>,
 }
+
+impl<S> Signal for FilteredSignal<S>
+where
+    S: Signal,
+{
+    // Output is the same type as the input.
+    type Frame = S::Frame;
+
+    fn next(&mut self) -> Self::Frame {
+        todo!("use `Sample::Float` in `signal`
+            instead of `ToSample`/`FromSample` in bounds")
+        // self.biquad.apply(self.signal.next())
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.signal.is_exhausted()
+    }
+}

--- a/dasp_signal/src/filter.rs
+++ b/dasp_signal/src/filter.rs
@@ -1,0 +1,9 @@
+//! An extension to the **Signal** trait that enables iterative filtering.
+//!
+//! ### Required Features
+//!
+//! - When using `dasp_signal`, this item requires the **filter** feature to be enabled.
+//! - When using `dasp`, this item requires the **signal-filter** feature to be enabled.
+
+use crate::Signal;
+use dasp_filter as filter;

--- a/dasp_signal/src/filter.rs
+++ b/dasp_signal/src/filter.rs
@@ -12,17 +12,36 @@ use dasp_sample::{Sample, FromSample};
 
 /// An extension to the **Signal** trait that enables iterative filtering.
 ///
+/// # Example
+///
+/// ```
+/// use dasp_filter::{self as filter, Coefficients};
+/// use dasp_signal::{self as signal, Signal};
+/// use dasp_signal::filter::SignalFilter;
+///
+/// fn main() {
+///     let signal = signal::rate(48000.0).const_hz(997.0).sine();
+///     // Notch filter to attenuate 997 Hz.
+///     let coeff = Coefficients {
+///         b0: 0.9157328640471359f64,
+///         b1: -1.8158910212730535,
+///         b2: 0.9157328640471359,
+///         a1: -1.8158910212730535,
+///         a2: 0.831465728094272,
+///     };
+///     let mut filtered = signal.filtered(coeff);
+///     assert_eq!(
+///         filtered.take(4).collect::<Vec<_>>(),
+///         vec![0.0, 0.11917058366454024, 0.21640079287630784, 0.2938740006664008]
+///     );
+/// }
+/// ```
+///
 /// ### Required Features
 ///
 /// - When using `dasp_signal`, this item requires the **filter** feature to be enabled.
 /// - When using `dasp`, this item requires the **signal-filter** feature to be enabled.
 pub trait SignalFilter: Signal {
-    /// An adaptor that calculates and yields a filtered signal.
-    ///
-    /// ### Required Features
-    ///
-    /// - When using `dasp_signal`, this item requires the **filter** feature to be enabled.
-    /// - When using `dasp`, this item requires the **signal-filter** feature to be enabled.
     fn filtered(
         self,
         coeff: filter::Coefficients<<<Self::Frame as Frame>::Sample as Sample>::Float>,
@@ -40,6 +59,12 @@ pub trait SignalFilter: Signal {
     }
 }
 
+/// An adaptor that calculates and yields a filtered signal.
+///
+/// ### Required Features
+///
+/// - When using `dasp_signal`, this item requires the **filter** feature to be enabled.
+/// - When using `dasp`, this item requires the **signal-filter** feature to be enabled.
 pub struct FilteredSignal<S>
 where
     S: Signal,
@@ -65,3 +90,6 @@ where
         self.signal.is_exhausted()
     }
 }
+
+// Impl this for all `Signal`s.
+impl<T> SignalFilter for T where T: Signal {}

--- a/dasp_signal/src/filter.rs
+++ b/dasp_signal/src/filter.rs
@@ -8,7 +8,7 @@
 use crate::Signal;
 use dasp_frame::Frame;
 use dasp_filter as filter;
-use dasp_sample::Sample;
+use dasp_sample::{Sample, FromSample};
 
 /// An extension to the **Signal** trait that enables iterative filtering.
 ///
@@ -29,6 +29,7 @@ pub trait SignalFilter: Signal {
     ) -> FilteredSignal<Self>
     where
         Self: Sized,
+        <Self::Frame as Frame>::Sample: FromSample<<<Self::Frame as Frame>::Sample as Sample>::Float>,
     {
         let biquad = filter::Biquad::from(coeff);
 
@@ -42,6 +43,7 @@ pub trait SignalFilter: Signal {
 pub struct FilteredSignal<S>
 where
     S: Signal,
+    <S::Frame as Frame>::Sample: FromSample<<<S::Frame as Frame>::Sample as Sample>::Float>,
 {
     signal: S,
     biquad: filter::Biquad<<S::Frame as Frame>::Float>,
@@ -50,14 +52,13 @@ where
 impl<S> Signal for FilteredSignal<S>
 where
     S: Signal,
+    <S::Frame as Frame>::Sample: FromSample<<<S::Frame as Frame>::Sample as Sample>::Float>,
 {
     // Output is the same type as the input.
     type Frame = S::Frame;
 
     fn next(&mut self) -> Self::Frame {
-        todo!("use `Sample::Float` in `signal`
-            instead of `ToSample`/`FromSample` in bounds")
-        // self.biquad.apply(self.signal.next())
+        self.biquad.apply(self.signal.next())
     }
 
     fn is_exhausted(&self) -> bool {

--- a/dasp_signal/src/filter.rs
+++ b/dasp_signal/src/filter.rs
@@ -6,4 +6,43 @@
 //! - When using `dasp`, this item requires the **signal-filter** feature to be enabled.
 
 use crate::Signal;
+use dasp_frame::Frame;
 use dasp_filter as filter;
+use dasp_sample::Sample;
+
+/// An extension to the **Signal** trait that enables iterative filtering.
+///
+/// ### Required Features
+///
+/// - When using `dasp_signal`, this item requires the **filter** feature to be enabled.
+/// - When using `dasp`, this item requires the **signal-filter** feature to be enabled.
+pub trait SignalFilter: Signal {
+    /// An adaptor that calculates and yields a filtered signal.
+    ///
+    /// ### Required Features
+    ///
+    /// - When using `dasp_signal`, this item requires the **filter** feature to be enabled.
+    /// - When using `dasp`, this item requires the **signal-filter** feature to be enabled.
+    fn filtered(
+        self,
+        coeff: filter::Coefficients<<<Self::Frame as Frame>::Sample as Sample>::Float>,
+    ) -> FilteredSignal<Self>
+    where
+        Self: Sized,
+    {
+        let biquad = filter::Biquad::from(coeff);
+
+        FilteredSignal {
+            signal: self,
+            biquad,
+        }
+    }
+}
+
+pub struct FilteredSignal<S>
+where
+    S: Signal,
+{
+    signal: S,
+    biquad: filter::Biquad<<S::Frame as Frame>::Float>,
+}

--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -63,6 +63,8 @@ mod boxed;
 pub mod bus;
 #[cfg(feature = "envelope")]
 pub mod envelope;
+#[cfg(feature = "filter")]
+pub mod filter;
 #[cfg(feature = "rms")]
 pub mod rms;
 #[cfg(feature = "window")]


### PR DESCRIPTION
Closes #145 

Adds a new subcrate `dasp_filter`, which included `Coefficients` and `Biquad` types. This crate uses the same feature gating as the other crates in `dasp`.

In addition, similar to how `envelope` is a subfeature in `dasp_signal`, I added `filter` similarly. This involves feature flags for the `dasp_signal` subcrate, plus an extension trait (`SignalFilter`) and iterator type (`FilteredSignal`) in `dasp_signal`, both of which are feature-gated.