### PR TITLE
add pulse wave signal source functions to the signal module

### DIFF
--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -949,6 +949,21 @@ pub struct Square<S> {
     phase: Phase<S>,
 }
 
+#[derive(Clone)]
+pub struct Pulse1<S> {
+    phase: Phase<S>,
+}
+
+#[derive(Clone)]
+pub struct Pulse2<S> {
+    phase: Phase<S>,
+}
+
+#[derive(Clone)]
+pub struct Pulse3<S> {
+    phase: Phase<S>,
+}
+
 /// A noise signal generator.
 #[derive(Clone)]
 pub struct Noise {
@@ -1519,6 +1534,78 @@ pub fn square<S>(phase: Phase<S>) -> Square<S> {
     Square { phase: phase }
 }
 
+/// Produces a `Signal` that yields a 12.5% duty cycle pulse wave oscillating at the given hz.
+///
+/// # Example
+///
+/// ```rust
+/// use dasp_signal::{self as signal, Signal};
+///
+/// fn main() {
+///     // Generates a square wave signal at 1hz to be sampled 8 times per second.
+///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse1();
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+/// }
+/// ```
+pub fn pulse1<S>(phase: Phase<S>) -> Pulse1<S> {
+    Pulse1 { phase: phase }
+}
+
+/// Produces a `Signal` that yields a 25% duty cycle pulse wave oscillating at the given hz.
+///
+/// # Example
+///
+/// ```rust
+/// use dasp_signal::{self as signal, Signal};
+///
+/// fn main() {
+///     // Generates a square wave signal at 1hz to be sampled 8 times per second.
+///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse2();
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+/// }
+/// ```
+pub fn pulse2<S>(phase: Phase<S>) -> Pulse2<S> {
+    Pulse2 { phase: phase }
+}
+
+/// Produces a `Signal` that yields a 75% duty cycle pulse wave oscillating at the given hz.
+///
+/// # Example
+///
+/// ```rust
+/// use dasp_signal::{self as signal, Signal};
+///
+/// fn main() {
+///     // Generates a square wave signal at 1hz to be sampled 8 times per second.
+///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse1();
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), 1.0);
+///     assert_eq!(signal.next(), -1.0);
+///     assert_eq!(signal.next(), -1.0);
+/// }
+/// ```
+pub fn pulse3<S>(phase: Phase<S>) -> Pulse3<S> {
+    Pulse3 { phase: phase }
+}
+
 /// Produces a `Signal` that yields random values between -1.0..1.0.
 ///
 /// # Example
@@ -1783,6 +1870,57 @@ where
     }
 }
 
+impl<S> Signal for Pulse1<S>
+where
+    S: Step,
+{
+    type Frame = f64;
+
+    #[inline]
+    fn next(&mut self) -> Self::Frame {
+        let phase = self.phase.next_phase();
+        if phase < 0.125 {
+            1.0
+        } else {
+            -1.0
+        }
+    }
+}
+
+impl<S> Signal for Pulse2<S>
+where
+    S: Step,
+{
+    type Frame = f64;
+
+    #[inline]
+    fn next(&mut self) -> Self::Frame {
+        let phase = self.phase.next_phase();
+        if phase < 0.25 {
+            1.0
+        } else {
+            -1.0
+        }
+    }
+}
+
+impl<S> Signal for Pulse3<S>
+where
+    S: Step,
+{
+    type Frame = f64;
+
+    #[inline]
+    fn next(&mut self) -> Self::Frame {
+        let phase = self.phase.next_phase();
+        if phase < 0.75 {
+            1.0
+        } else {
+            -1.0
+        }
+    }
+}
+
 impl Rate {
     /// Create a `ConstHz` signal which consistently yields `hz / rate`.
     pub fn const_hz(self, hz: f64) -> ConstHz {
@@ -1845,6 +1983,24 @@ where
         self.phase().square()
     }
 
+    /// A composable alternative to the `signal::pulse1` function.
+    #[inline]
+    pub fn pulse1(self) -> Pulse1<Self> {
+        self.phase().pulse1()
+    }
+
+    /// A composable alternative to the `signal::pulse2` function.
+    #[inline]
+    pub fn pulse2(self) -> Pulse2<Self> {
+        self.phase().pulse2()
+    }
+
+    /// A composable alternative to the `signal::pulse3` function.
+    #[inline]
+    pub fn pulse3(self) -> Pulse3<Self> {
+        self.phase().pulse3()
+    }
+
     /// A composable alternative to the `signal::noise_simplex` function.
     #[inline]
     pub fn noise_simplex(self) -> NoiseSimplex<Self> {
@@ -1875,6 +2031,24 @@ impl ConstHz {
     #[inline]
     pub fn square(self) -> Square<Self> {
         self.phase().square()
+    }
+
+    /// A composable alternative to the `signal::pulse1` function.
+    #[inline]
+    pub fn pulse1(self) -> Pulse1<Self> {
+        self.phase().pulse1()
+    }
+
+    /// A composable alternative to the `signal::pulse2` function.
+    #[inline]
+    pub fn pulse2(self) -> Pulse2<Self> {
+        self.phase().pulse2()
+    }
+
+    /// A composable alternative to the `signal::pulse3` function.
+    #[inline]
+    pub fn pulse3(self) -> Pulse3<Self> {
+        self.phase().pulse3()
     }
 
     /// A composable alternative to the `signal::noise_simplex` function.
@@ -1950,6 +2124,24 @@ where
     #[inline]
     pub fn square(self) -> Square<S> {
         square(self)
+    }
+
+    /// A composable version of the `signal::pulse1` function.
+    #[inline]
+    pub fn pulse1(self) -> Pulse1<S> {
+        pulse1(self)
+    }
+
+    /// A composable version of the `signal::pulse2` function.
+    #[inline]
+    pub fn pulse2(self) -> Pulse2<S> {
+        pulse2(self)
+    }
+
+    /// A composable version of the `signal::pulse3` function.
+    #[inline]
+    pub fn pulse3(self) -> Pulse3<S> {
+        pulse3(self)
     }
 
     /// A composable version of the `signal::noise_simplex` function.

--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -1591,7 +1591,7 @@ pub fn pulse2<S>(phase: Phase<S>) -> Pulse2<S> {
 ///
 /// fn main() {
 ///     // Generates a square wave signal at 1hz to be sampled 8 times per second.
-///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse1();
+///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse3();
 ///     assert_eq!(signal.next(), 1.0);
 ///     assert_eq!(signal.next(), 1.0);
 ///     assert_eq!(signal.next(), 1.0);

--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -1985,19 +1985,19 @@ where
 
     /// A composable alternative to the `signal::pulse12` function.
     #[inline]
-    pub fn pulse12(self) -> pulse12<Self> {
+    pub fn pulse12(self) -> Pulse12<Self> {
         self.phase().pulse12()
     }
 
     /// A composable alternative to the `signal::pulse25` function.
     #[inline]
-    pub fn pulse25(self) -> pulse25<Self> {
+    pub fn pulse25(self) -> Pulse25<Self> {
         self.phase().pulse25()
     }
 
     /// A composable alternative to the `signal::pulse75` function.
     #[inline]
-    pub fn pulse75(self) -> pulse75<Self> {
+    pub fn pulse75(self) -> Pulse75<Self> {
         self.phase().pulse75()
     }
 
@@ -2035,19 +2035,19 @@ impl ConstHz {
 
     /// A composable alternative to the `signal::pulse12` function.
     #[inline]
-    pub fn pulse12(self) -> pulse12<Self> {
+    pub fn pulse12(self) -> Pulse12<Self> {
         self.phase().pulse12()
     }
 
     /// A composable alternative to the `signal::pulse25` function.
     #[inline]
-    pub fn pulse25(self) -> pulse25<Self> {
+    pub fn pulse25(self) -> Pulse25<Self> {
         self.phase().pulse25()
     }
 
     /// A composable alternative to the `signal::pulse75` function.
     #[inline]
-    pub fn pulse75(self) -> pulse75<Self> {
+    pub fn pulse75(self) -> Pulse75<Self> {
         self.phase().pulse75()
     }
 
@@ -2128,19 +2128,19 @@ where
 
     /// A composable version of the `signal::pulse12` function.
     #[inline]
-    pub fn pulse12(self) -> pulse12<S> {
+    pub fn pulse12(self) -> Pulse12<S> {
         pulse12(self)
     }
 
     /// A composable version of the `signal::pulse25` function.
     #[inline]
-    pub fn pulse25(self) -> pulse25<S> {
+    pub fn pulse25(self) -> Pulse25<S> {
         pulse25(self)
     }
 
     /// A composable version of the `signal::pulse75` function.
     #[inline]
-    pub fn pulse75(self) -> pulse75<S> {
+    pub fn pulse75(self) -> Pulse75<S> {
         pulse75(self)
     }
 

--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -950,17 +950,17 @@ pub struct Square<S> {
 }
 
 #[derive(Clone)]
-pub struct Pulse1<S> {
+pub struct Pulse12<S> {
     phase: Phase<S>,
 }
 
 #[derive(Clone)]
-pub struct Pulse2<S> {
+pub struct Pulse25<S> {
     phase: Phase<S>,
 }
 
 #[derive(Clone)]
-pub struct Pulse3<S> {
+pub struct Pulse75<S> {
     phase: Phase<S>,
 }
 
@@ -1543,7 +1543,7 @@ pub fn square<S>(phase: Phase<S>) -> Square<S> {
 ///
 /// fn main() {
 ///     // Generates a square wave signal at 1hz to be sampled 8 times per second.
-///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse1();
+///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse12();
 ///     assert_eq!(signal.next(), 1.0);
 ///     assert_eq!(signal.next(), -1.0);
 ///     assert_eq!(signal.next(), -1.0);
@@ -1554,8 +1554,8 @@ pub fn square<S>(phase: Phase<S>) -> Square<S> {
 ///     assert_eq!(signal.next(), -1.0);
 /// }
 /// ```
-pub fn pulse1<S>(phase: Phase<S>) -> Pulse1<S> {
-    Pulse1 { phase: phase }
+pub fn pulse12<S>(phase: Phase<S>) -> Pulse12<S> {
+    pulse12 { phase: phase }
 }
 
 /// Produces a `Signal` that yields a 25% duty cycle pulse wave oscillating at the given hz.
@@ -1567,7 +1567,7 @@ pub fn pulse1<S>(phase: Phase<S>) -> Pulse1<S> {
 ///
 /// fn main() {
 ///     // Generates a square wave signal at 1hz to be sampled 8 times per second.
-///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse2();
+///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse25();
 ///     assert_eq!(signal.next(), 1.0);
 ///     assert_eq!(signal.next(), 1.0);
 ///     assert_eq!(signal.next(), -1.0);
@@ -1578,8 +1578,8 @@ pub fn pulse1<S>(phase: Phase<S>) -> Pulse1<S> {
 ///     assert_eq!(signal.next(), -1.0);
 /// }
 /// ```
-pub fn pulse2<S>(phase: Phase<S>) -> Pulse2<S> {
-    Pulse2 { phase: phase }
+pub fn pulse25<S>(phase: Phase<S>) -> Pulse25<S> {
+    pulse25 { phase: phase }
 }
 
 /// Produces a `Signal` that yields a 75% duty cycle pulse wave oscillating at the given hz.
@@ -1591,7 +1591,7 @@ pub fn pulse2<S>(phase: Phase<S>) -> Pulse2<S> {
 ///
 /// fn main() {
 ///     // Generates a square wave signal at 1hz to be sampled 8 times per second.
-///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse3();
+///     let mut signal = signal::rate(8.0).const_hz(1.0).pulse75();
 ///     assert_eq!(signal.next(), 1.0);
 ///     assert_eq!(signal.next(), 1.0);
 ///     assert_eq!(signal.next(), 1.0);
@@ -1602,8 +1602,8 @@ pub fn pulse2<S>(phase: Phase<S>) -> Pulse2<S> {
 ///     assert_eq!(signal.next(), -1.0);
 /// }
 /// ```
-pub fn pulse3<S>(phase: Phase<S>) -> Pulse3<S> {
-    Pulse3 { phase: phase }
+pub fn pulse75<S>(phase: Phase<S>) -> Pulse75<S> {
+    pulse75 { phase: phase }
 }
 
 /// Produces a `Signal` that yields random values between -1.0..1.0.
@@ -1870,7 +1870,7 @@ where
     }
 }
 
-impl<S> Signal for Pulse1<S>
+impl<S> Signal for Pulse12<S>
 where
     S: Step,
 {
@@ -1887,7 +1887,7 @@ where
     }
 }
 
-impl<S> Signal for Pulse2<S>
+impl<S> Signal for Pulse25<S>
 where
     S: Step,
 {
@@ -1904,7 +1904,7 @@ where
     }
 }
 
-impl<S> Signal for Pulse3<S>
+impl<S> Signal for Pulse75<S>
 where
     S: Step,
 {
@@ -1983,22 +1983,22 @@ where
         self.phase().square()
     }
 
-    /// A composable alternative to the `signal::pulse1` function.
+    /// A composable alternative to the `signal::pulse12` function.
     #[inline]
-    pub fn pulse1(self) -> Pulse1<Self> {
-        self.phase().pulse1()
+    pub fn pulse12(self) -> pulse12<Self> {
+        self.phase().pulse12()
     }
 
-    /// A composable alternative to the `signal::pulse2` function.
+    /// A composable alternative to the `signal::pulse25` function.
     #[inline]
-    pub fn pulse2(self) -> Pulse2<Self> {
-        self.phase().pulse2()
+    pub fn pulse25(self) -> pulse25<Self> {
+        self.phase().pulse25()
     }
 
-    /// A composable alternative to the `signal::pulse3` function.
+    /// A composable alternative to the `signal::pulse75` function.
     #[inline]
-    pub fn pulse3(self) -> Pulse3<Self> {
-        self.phase().pulse3()
+    pub fn pulse75(self) -> pulse75<Self> {
+        self.phase().pulse75()
     }
 
     /// A composable alternative to the `signal::noise_simplex` function.
@@ -2033,22 +2033,22 @@ impl ConstHz {
         self.phase().square()
     }
 
-    /// A composable alternative to the `signal::pulse1` function.
+    /// A composable alternative to the `signal::pulse12` function.
     #[inline]
-    pub fn pulse1(self) -> Pulse1<Self> {
-        self.phase().pulse1()
+    pub fn pulse12(self) -> pulse12<Self> {
+        self.phase().pulse12()
     }
 
-    /// A composable alternative to the `signal::pulse2` function.
+    /// A composable alternative to the `signal::pulse25` function.
     #[inline]
-    pub fn pulse2(self) -> Pulse2<Self> {
-        self.phase().pulse2()
+    pub fn pulse25(self) -> pulse25<Self> {
+        self.phase().pulse25()
     }
 
-    /// A composable alternative to the `signal::pulse3` function.
+    /// A composable alternative to the `signal::pulse75` function.
     #[inline]
-    pub fn pulse3(self) -> Pulse3<Self> {
-        self.phase().pulse3()
+    pub fn pulse75(self) -> pulse75<Self> {
+        self.phase().pulse75()
     }
 
     /// A composable alternative to the `signal::noise_simplex` function.
@@ -2126,22 +2126,22 @@ where
         square(self)
     }
 
-    /// A composable version of the `signal::pulse1` function.
+    /// A composable version of the `signal::pulse12` function.
     #[inline]
-    pub fn pulse1(self) -> Pulse1<S> {
-        pulse1(self)
+    pub fn pulse12(self) -> pulse12<S> {
+        pulse12(self)
     }
 
-    /// A composable version of the `signal::pulse2` function.
+    /// A composable version of the `signal::pulse25` function.
     #[inline]
-    pub fn pulse2(self) -> Pulse2<S> {
-        pulse2(self)
+    pub fn pulse25(self) -> pulse25<S> {
+        pulse25(self)
     }
 
-    /// A composable version of the `signal::pulse3` function.
+    /// A composable version of the `signal::pulse75` function.
     #[inline]
-    pub fn pulse3(self) -> Pulse3<S> {
-        pulse3(self)
+    pub fn pulse75(self) -> pulse75<S> {
+        pulse75(self)
     }
 
     /// A composable version of the `signal::noise_simplex` function.

--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -1555,7 +1555,7 @@ pub fn square<S>(phase: Phase<S>) -> Square<S> {
 /// }
 /// ```
 pub fn pulse12<S>(phase: Phase<S>) -> Pulse12<S> {
-    pulse12 { phase: phase }
+    Pulse12 { phase: phase }
 }
 
 /// Produces a `Signal` that yields a 25% duty cycle pulse wave oscillating at the given hz.
@@ -1579,7 +1579,7 @@ pub fn pulse12<S>(phase: Phase<S>) -> Pulse12<S> {
 /// }
 /// ```
 pub fn pulse25<S>(phase: Phase<S>) -> Pulse25<S> {
-    pulse25 { phase: phase }
+    Pulse25 { phase: phase }
 }
 
 /// Produces a `Signal` that yields a 75% duty cycle pulse wave oscillating at the given hz.
@@ -1603,7 +1603,7 @@ pub fn pulse25<S>(phase: Phase<S>) -> Pulse25<S> {
 /// }
 /// ```
 pub fn pulse75<S>(phase: Phase<S>) -> Pulse75<S> {
-    pulse75 { phase: phase }
+    Pulse75 { phase: phase }
 }
 
 /// Produces a `Signal` that yields random values between -1.0..1.0.


### PR DESCRIPTION
I added three pulse wave source functions to the dasp::signal module, that I felt would be useful.
I chose to add a selection 12.5%, 25%, and 75% duty cycle pulse waves.

My reasoning for this was due to those 3, (plus 50%, as standard Square Wave) being the most common in chiptune, and old gaming APU's.

Initially I tried extending the signal module in my own project, but came across some difficulty trying to implement it as a trait.