### PR TITLE
Use const generics in graph module

### DIFF
--- a/dasp_graph/src/buffer.rs
+++ b/dasp_graph/src/buffer.rs
@@ -3,16 +3,15 @@ use core::ops::{Deref, DerefMut};
 
 /// The fixed-size buffer used for processing the graph.
 #[derive(Clone)]
-pub struct Buffer {
-    data: [f32; Self::LEN],
+pub struct Buffer<const N: usize> {
+    data: [f32; N],
 }
 
-impl Buffer {
-    /// The fixed length of the **Buffer** type.
-    pub const LEN: usize = 64;
+impl<const N: usize> Buffer<N> {
+    pub const LEN: usize = N;
     /// A silent **Buffer**.
     pub const SILENT: Self = Buffer {
-        data: [0.0; Self::LEN],
+        data: [0.0; N],
     };
 
     /// Short-hand for writing silence to the whole buffer.
@@ -21,38 +20,38 @@ impl Buffer {
     }
 }
 
-impl Default for Buffer {
+impl<const N: usize> Default for Buffer<N> {
     fn default() -> Self {
         Self::SILENT
     }
 }
 
-impl From<[f32; Self::LEN]> for Buffer {
-    fn from(data: [f32; Self::LEN]) -> Self {
+impl<const N: usize> From<[f32; N]> for Buffer<N> {
+    fn from(data: [f32; N]) -> Self {
         Buffer { data }
     }
 }
 
-impl fmt::Debug for Buffer {
+impl<const N: usize> fmt::Debug for Buffer<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.data[..], f)
     }
 }
 
-impl PartialEq for Buffer {
+impl<const N: usize> PartialEq for Buffer<N> {
     fn eq(&self, other: &Self) -> bool {
         &self[..] == &other[..]
     }
 }
 
-impl Deref for Buffer {
+impl<const N: usize> Deref for Buffer<N> {
     type Target = [f32];
     fn deref(&self) -> &Self::Target {
         &self.data[..]
     }
 }
 
-impl DerefMut for Buffer {
+impl<const N: usize> DerefMut for Buffer<N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.data[..]
     }

--- a/dasp_graph/src/node/boxed.rs
+++ b/dasp_graph/src/node/boxed.rs
@@ -6,7 +6,7 @@ use core::ops::{Deref, DerefMut};
 ///
 /// Provides the necessary `Sized` implementation to allow for compatibility with the graph process
 /// function.
-pub struct BoxedNode(pub Box<dyn Node>);
+pub struct BoxedNode<const N: usize>(pub Box<dyn Node<N>>);
 
 /// A wrapper around a `Box<dyn Node>`.
 ///
@@ -16,107 +16,107 @@ pub struct BoxedNode(pub Box<dyn Node>);
 /// Useful when the ability to send nodes from one thread to another is required. E.g. this is
 /// common when initialising nodes or the audio graph itself on one thread before sending them to
 /// the audio thread.
-pub struct BoxedNodeSend(pub Box<dyn Node + Send>);
+pub struct BoxedNodeSend<const N: usize>(pub Box<dyn Node<N> + Send>);
 
-impl BoxedNode {
+impl<const N: usize> BoxedNode<N> {
     /// Create a new `BoxedNode` around the given `node`.
     ///
     /// This is short-hand for `BoxedNode::from(Box::new(node))`.
     pub fn new<T>(node: T) -> Self
     where
-        T: 'static + Node,
+        T: 'static + Node<N>,
     {
         Self::from(Box::new(node))
     }
 }
 
-impl BoxedNodeSend {
+impl<const N: usize> BoxedNodeSend<N> {
     /// Create a new `BoxedNode` around the given `node`.
     ///
     /// This is short-hand for `BoxedNode::from(Box::new(node))`.
     pub fn new<T>(node: T) -> Self
     where
-        T: 'static + Node + Send,
+        T: 'static + Node<N> + Send,
     {
         Self::from(Box::new(node))
     }
 }
 
-impl Node for BoxedNode {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<const N: usize> Node<N> for BoxedNode<N> {
+    fn process(&mut self, inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         self.0.process(inputs, output)
     }
 }
 
-impl Node for BoxedNodeSend {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<const N: usize> Node<N> for BoxedNodeSend<N> {
+    fn process(&mut self, inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         self.0.process(inputs, output)
     }
 }
 
-impl<T> From<Box<T>> for BoxedNode
+impl<T, const N: usize> From<Box<T>> for BoxedNode<N>
 where
-    T: 'static + Node,
+    T: 'static + Node<N>,
 {
     fn from(n: Box<T>) -> Self {
-        BoxedNode(n as Box<dyn Node>)
+        BoxedNode(n as Box<dyn Node<N>>)
     }
 }
 
-impl<T> From<Box<T>> for BoxedNodeSend
+impl<T, const N: usize> From<Box<T>> for BoxedNodeSend<N>
 where
-    T: 'static + Node + Send,
+    T: 'static + Node<N> + Send,
 {
     fn from(n: Box<T>) -> Self {
-        BoxedNodeSend(n as Box<dyn Node + Send>)
+        BoxedNodeSend(n as Box<dyn Node<N> + Send>)
     }
 }
 
-impl Into<Box<dyn Node>> for BoxedNode {
-    fn into(self) -> Box<dyn Node> {
+impl<const N: usize> Into<Box<dyn Node<N>>> for BoxedNode<N> {
+    fn into(self) -> Box<dyn Node<N>> {
         self.0
     }
 }
 
-impl Into<Box<dyn Node + Send>> for BoxedNodeSend {
-    fn into(self) -> Box<dyn Node + Send> {
+impl<const N: usize> Into<Box<dyn Node<N> + Send>> for BoxedNodeSend<N> {
+    fn into(self) -> Box<dyn Node<N> + Send> {
         self.0
     }
 }
 
-impl fmt::Debug for BoxedNode {
+impl<const N: usize> fmt::Debug for BoxedNode<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BoxedNode").finish()
     }
 }
 
-impl fmt::Debug for BoxedNodeSend {
+impl<const N: usize> fmt::Debug for BoxedNodeSend<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BoxedNodeSend").finish()
     }
 }
 
-impl Deref for BoxedNode {
-    type Target = Box<dyn Node>;
+impl<const N: usize> Deref for BoxedNode<N> {
+    type Target = Box<dyn Node<N>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl Deref for BoxedNodeSend {
-    type Target = Box<dyn Node + Send>;
+impl<const N: usize> Deref for BoxedNodeSend<N> {
+    type Target = Box<dyn Node<N> + Send>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for BoxedNode {
+impl<const N: usize> DerefMut for BoxedNode<N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl DerefMut for BoxedNodeSend {
+impl<const N: usize> DerefMut for BoxedNodeSend<N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/dasp_graph/src/node/delay.rs
+++ b/dasp_graph/src/node/delay.rs
@@ -9,11 +9,11 @@ use dasp_ring_buffer as ring_buffer;
 #[derive(Clone, Debug, PartialEq)]
 pub struct Delay<S>(pub Vec<ring_buffer::Fixed<S>>);
 
-impl<S> Node for Delay<S>
+impl<S, const N: usize> Node<N> for Delay<S>
 where
     S: ring_buffer::SliceMut<Element = f32>,
 {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         // Retrieve the single input, ignore any others.
         let input = match inputs.get(0) {
             Some(input) => input,

--- a/dasp_graph/src/node/graph.rs
+++ b/dasp_graph/src/node/graph.rs
@@ -7,24 +7,24 @@ use core::marker::PhantomData;
 use petgraph::data::DataMapMut;
 use petgraph::visit::{Data, GraphBase, IntoNeighborsDirected, Visitable};
 
-pub struct GraphNode<G, T>
+pub struct GraphNode<G, T, const N: usize>
 where
     G: Visitable,
 {
-    pub processor: Processor<G>,
+    pub processor: Processor<G, N>,
     pub graph: G,
     pub input_nodes: Vec<G::NodeId>,
     pub output_node: G::NodeId,
     pub node_type: PhantomData<T>,
 }
 
-impl<G, T> Node for GraphNode<G, T>
+impl<G, T, const N: usize> Node<N> for GraphNode<G, T, N>
 where
-    G: Data<NodeWeight = NodeData<T>> + DataMapMut + Visitable,
+    G: Data<NodeWeight = NodeData<T, N>> + DataMapMut + Visitable,
     for<'a> &'a G: GraphBase<NodeId = G::NodeId> + IntoNeighborsDirected,
-    T: Node,
+    T: Node<N>,
 {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         let GraphNode {
             ref mut processor,
             ref mut graph,

--- a/dasp_graph/src/node/pass.rs
+++ b/dasp_graph/src/node/pass.rs
@@ -10,8 +10,8 @@ use crate::{Buffer, Input, Node};
 #[derive(Clone, Debug, PartialEq)]
 pub struct Pass;
 
-impl Node for Pass {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<const N: usize> Node<N> for Pass {
+    fn process(&mut self, inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         let input = match inputs.get(0) {
             None => return,
             Some(input) => input,

--- a/dasp_graph/src/node/signal.rs
+++ b/dasp_graph/src/node/signal.rs
@@ -2,13 +2,13 @@ use crate::{Buffer, Input, Node};
 use dasp_frame::Frame;
 use dasp_signal::Signal;
 
-impl<F> Node for dyn Signal<Frame = F>
+impl<F, const N: usize> Node<N> for dyn Signal<Frame = F>
 where
     F: Frame<Sample = f32>,
 {
-    fn process(&mut self, _inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, _inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         let channels = std::cmp::min(F::CHANNELS, output.len());
-        for ix in 0..Buffer::LEN {
+        for ix in 0..N {
             let frame = self.next();
             for ch in 0..channels {
                 // Safe, as we verify the number of channels at the beginning of the function.

--- a/dasp_graph/src/node/sum.rs
+++ b/dasp_graph/src/node/sum.rs
@@ -22,8 +22,8 @@ pub struct Sum;
 #[derive(Clone, Debug, PartialEq)]
 pub struct SumBuffers;
 
-impl Node for Sum {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<const N: usize> Node<N> for Sum {
+    fn process(&mut self, inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         // Fill the output with silence.
         for out_buffer in output.iter_mut() {
             out_buffer.silence();
@@ -40,8 +40,8 @@ impl Node for Sum {
     }
 }
 
-impl Node for SumBuffers {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<const N: usize> Node<N> for SumBuffers {
+    fn process(&mut self, inputs: &[Input<N>], output: &mut [Buffer<N>]) {
         // Get the first output buffer.
         let mut out_buffers = output.iter_mut();
         let out_buffer_first = match out_buffers.next() {

--- a/dasp_graph/tests/graph_send.rs
+++ b/dasp_graph/tests/graph_send.rs
@@ -11,8 +11,8 @@ use petgraph::visit::GraphBase;
 #[test]
 #[should_panic]
 fn test_graph_send() {
-    type Graph = petgraph::Graph<NodeData<BoxedNodeSend>, (), petgraph::Directed, u32>;
-    type Processor = dasp_graph::Processor<Graph>;
+    type Graph = petgraph::Graph<NodeData<BoxedNodeSend<128>, 128>, (), petgraph::Directed, u32>;
+    type Processor = dasp_graph::Processor<Graph, 128>;
     let mut g: Graph = unimplemented!();
     let mut p: Processor = unimplemented!();
     let n: <Graph as GraphBase>::NodeId = unimplemented!();

--- a/dasp_graph/tests/graph_types.rs
+++ b/dasp_graph/tests/graph_types.rs
@@ -11,8 +11,8 @@ use petgraph::visit::GraphBase;
 #[test]
 #[should_panic]
 fn test_graph() {
-    type Graph = petgraph::Graph<NodeData<BoxedNode>, (), petgraph::Directed, u32>;
-    type Processor = dasp_graph::Processor<Graph>;
+    type Graph = petgraph::Graph<NodeData::<BoxedNode::<128>, 128>, (), petgraph::Directed, u32>;
+    type Processor = dasp_graph::Processor<Graph, 128>;
     let mut g: Graph = unimplemented!();
     let mut p: Processor = unimplemented!();
     let n: <Graph as GraphBase>::NodeId = unimplemented!();
@@ -23,8 +23,8 @@ fn test_graph() {
 #[should_panic]
 fn test_stable_graph() {
     type Graph =
-        petgraph::stable_graph::StableGraph<NodeData<BoxedNode>, (), petgraph::Directed, u32>;
-    type Processor = dasp_graph::Processor<Graph>;
+        petgraph::stable_graph::StableGraph<NodeData<BoxedNode<128>, 128>, (), petgraph::Directed, u32>;
+    type Processor = dasp_graph::Processor<Graph, 128>;
     let mut g: Graph = unimplemented!();
     let mut p: Processor = unimplemented!();
     let n: <Graph as GraphBase>::NodeId = unimplemented!();


### PR DESCRIPTION
The graph module uses a fixed length of 64, which limits its usage in many contexts such as web audio.

`#![feature(min_const_generics)]` can solve this issue, and will become stable in Rust 1.51
https://github.com/rust-lang/rust/pull/79135

Currently tested successful and can be compiled using nightly version of rustc.