### PR TITLE
Fix compiler error on 1.50.0

### DIFF
--- a/dasp_window/src/hanning/mod.rs
+++ b/dasp_window/src/hanning/mod.rs
@@ -22,7 +22,7 @@ where
     type Output = S;
     fn window(phase: S) -> Self::Output {
         const PI_2: f64 = core::f64::consts::PI * 2.0;
-        let v = phase.to_float_sample().to_sample() * PI_2;
+        let v = phase.to_float_sample().to_sample::<f64>() * PI_2;
         (0.5 * (1.0 - cos(v)))
             .to_sample::<S::Float>()
             .to_sample::<S>()


### PR DESCRIPTION
Backport of  #137 for the 0.11 branch. c #136 and #141 .