### PR TITLE
Use const generics in the ring_buffer module

### DIFF
--- a/dasp_ring_buffer/src/lib.rs
+++ b/dasp_ring_buffer/src/lib.rs
@@ -106,35 +106,24 @@ impl<T> SliceMut for Vec<T> {
     }
 }
 
-macro_rules! impl_slice_for_arrays {
-    ($($N:expr)*) => {
-        $(
-            impl<T> Slice for [T; $N] {
-                type Element = T;
-                #[inline]
-                fn slice(&self) -> &[Self::Element] {
-                    &self[..]
-                }
-            }
-            impl<T> SliceMut for [T; $N] {
-                #[inline]
-                fn slice_mut(&mut self) -> &mut [Self::Element] {
-                    &mut self[..]
-                }
-            }
-            impl<T> FixedSizeArray for [T; $N] {
-                const LEN: usize = $N;
-            }
-        )*
-    };
+impl<T, const N: usize> Slice for [T; N] {
+    type Element = T;
+
+    #[inline]
+    fn slice(&self) -> &[Self::Element] {
+        &self[..]
+    }
 }
 
-impl_slice_for_arrays! {
-    1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34
-    35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65
-    66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96
-    97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120
-    121 122 123 124 125 126 127 128 256 512 1024 2048 4096 8192
+impl<T, const N: usize> SliceMut for [T; N] {
+    #[inline]
+    fn slice_mut(&mut self) -> &mut [Self::Element] {
+        &mut self[..]
+    }
+}
+
+impl<T, const N: usize> FixedSizeArray for [T; N] {
+    const LEN: usize = N;
 }
 
 /////////////////////////////


### PR DESCRIPTION
Since const generics have been stable for a while now, I thought that it was time that this crate made use of them too. It is unnecessarily restrictive to only have a couple of sizes to choose from, and to use a size that isn't supported by arrays, you have to use a heap allocation which isn't always optimal. With const generics, its possible to store arbitrarily sized buffers on the stack instead.