### PR TITLE
Run cargo-fmt on repository. Fix broken link for github actions badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
 
-[dasp-actions]: https://github.com/nannou-org/dasp/actions
+[dasp-actions]: https://github.com/rustaudio/dasp/actions
 [dasp-actions-svg]: https://github.com/rustaudio/dasp/workflows/dasp/badge.svg
 [deps-graph]: ./assets/deps-graph.png
 [dasp]: ./dasp

--- a/dasp_ring_buffer/src/lib.rs
+++ b/dasp_ring_buffer/src/lib.rs
@@ -401,7 +401,7 @@ where
 
 impl<S> Extend<S::Element> for Fixed<S>
 where
-    S: SliceMut
+    S: SliceMut,
 {
     fn extend<T: IntoIterator<Item = S::Element>>(&mut self, iter: T) {
         for item in iter {
@@ -867,7 +867,7 @@ where
 }
 
 impl<S> Extend<S::Element> for Bounded<S>
-where 
+where
     S: SliceMut,
     S::Element: Copy,
 {


### PR DESCRIPTION
I accidentally merged https://github.com/RustAudio/dasp/pull/160 not realising the `cargo fmt` check wasn't passing - it seems CI didn't run automatically for the PR and there wasn't the regular option to "Approve and Run Workflow"? Or maybe I missed it. Either way, this fixes the formatting issues.

Also fixes the link so that clicking the actions badge takes you to the "actions" tab for this repository.