### PR TITLE
Add reset method to Interpolator

### DIFF
--- a/dasp_interpolate/src/floor.rs
+++ b/dasp_interpolate/src/floor.rs
@@ -45,4 +45,8 @@ where
     fn next_source_frame(&mut self, source_frame: Self::Frame) {
         self.left = source_frame;
     }
+
+    fn reset(&mut self) {
+        self.left = Self::Frame::EQUILIBRIUM;
+    }
 }

--- a/dasp_interpolate/src/lib.rs
+++ b/dasp_interpolate/src/lib.rs
@@ -48,4 +48,9 @@ pub trait Interpolator {
 
     /// To be called whenever the Interpolator value steps passed 1.0.
     fn next_source_frame(&mut self, source_frame: Self::Frame);
+
+    /// Resets the state of the interpolator.
+    ///
+    /// Call this when there's a break in the continuity of the input data stream.
+    fn reset(&mut self);
 }

--- a/dasp_interpolate/src/linear.rs
+++ b/dasp_interpolate/src/linear.rs
@@ -59,4 +59,9 @@ where
         self.left = self.right;
         self.right = source_frame;
     }
+
+    fn reset(&mut self) {
+        self.left = Self::Frame::EQUILIBRIUM;
+        self.right = Self::Frame::EQUILIBRIUM;
+    }
 }

--- a/dasp_interpolate/src/sinc/mod.rs
+++ b/dasp_interpolate/src/sinc/mod.rs
@@ -121,4 +121,12 @@ where
             self.idx += 1;
         }
     }
+
+    fn reset(&mut self) {
+        self.idx = 0;
+        self.frames.set_first(0);
+        for frame in self.frames.iter_mut() {
+            *frame = Self::Frame::EQUILIBRIUM;
+        }
+    }
 }


### PR DESCRIPTION
Adds a new method to the Interpolator trait, that resets Interpolator state.

Closes #162.