### PR TITLE
Make IntoInterleavedSamples(Iterator) stop yielding samples on exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 - Renamed `window-hanning` to `window-hann`
+- Made `IntoInterleavedSamples` and `IntoInterleavedSamplesIterator` stop
+  yielding samples when the underlying signal gets exhausted. This is a breaking
+  change. The return type of the `IntoInterleavedSamples#next_sample` method was
+  modified.
 
 ---
 

--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -2286,6 +2286,7 @@ where
     S: Signal,
 {
     /// Yield the next interleaved sample from the inner `Signal`.
+    ///
     /// The returned value is `None` if the signal is exhausted.
     #[inline]
     pub fn next_sample(&mut self) -> Option<<S::Frame as Frame>::Sample> {

--- a/dasp_signal/src/lib.rs
+++ b/dasp_signal/src/lib.rs
@@ -2285,8 +2285,8 @@ impl<S> IntoInterleavedSamples<S>
 where
     S: Signal,
 {
-    /// Yield the next interleaved sample from the inner `Signal`. The returned value
-    /// is `None` if the signal is exhausted.
+    /// Yield the next interleaved sample from the inner `Signal`.
+    /// The returned value is `None` if the signal is exhausted.
     #[inline]
     pub fn next_sample(&mut self) -> Option<<S::Frame as Frame>::Sample> {
         if self.current_frame.is_none() && !self.signal.is_exhausted() {


### PR DESCRIPTION
`IntoInterleavedSamples`, especially its companion `IntoInterleavedSamplesIterator` type, is, in my opinion, very useful to easily process samples from an audio signal with elegance.

However, these helper types do not handle the source signal being exhausted at all. When the signal is exhausted, they always return equilibrium-valued samples, turning finite signals into infinite ones in an arguably counter-intuitive manner. I also think that quirk, even though it is documented, is somewhat hard to discover, because it is indirectly mentioned in the description of the `IntoInterleavedSamplesIterator` type, which is not shown when using the features of most IDEs.

In particular, I think the following reasons justify this change to achieve a better API:

- Exhaustion is contagious for the rest of adapters returned by `Signal` methods. It's inconsistent that `into_interleaved_samples` behaves differently.
- In some scenarios the total number of samples of a finite signal is not known in advance, and is not feasible to read it all to a buffer. Also, valid samples may have a value that is numerically equal to the equilibrium value, so checking for equilibrium values is not a good solution. On the contrary, it always is possible to make the finite sequence infinite easily. When dealing with iterators, this is as easy as calling `.chain(std::iter::repeat(f32::EQUILIBRIUM))`, for example.
- It provides for more elegant and failure-proof client code in some cases. For example, the following code now terminates when the input signal is finite, as I think most people would expect:

```rust
dasp_signal::from_interleaved_samples_iter::<_, Stereo<f32>>(signal.into_interleaved_samples().into_iter().map(|s| s * 2)))
```

To address this situation, these changes modify how the related methods are implemented and their signatures. `cargo test` runs successfully, and I have updated the related examples and documentation accordingly.