### PR TITLE
dasp_graph: Pass edge weights to Node::process

### DIFF
--- a/dasp_graph/src/lib.rs
+++ b/dasp_graph/src/lib.rs
@@ -270,11 +270,11 @@ impl<T> NodeData<T> {
 }
 
 #[cfg(feature = "node-boxed")]
-impl NodeData<BoxedNode> {
+impl<W> NodeData<BoxedNode<W>> {
     /// The same as **new**, but boxes the given node data before storing it.
     pub fn boxed<T>(node: T, buffers: Vec<Buffer>) -> Self
     where
-        T: 'static + Node,
+        T: 'static + Node<W>,
     {
         NodeData::new(BoxedNode(Box::new(node)), buffers)
     }
@@ -282,7 +282,7 @@ impl NodeData<BoxedNode> {
     /// The same as **new1**, but boxes the given node data before storing it.
     pub fn boxed1<T>(node: T) -> Self
     where
-        T: 'static + Node,
+        T: 'static + Node<W>,
     {
         Self::boxed(node, vec![Buffer::SILENT])
     }
@@ -290,7 +290,7 @@ impl NodeData<BoxedNode> {
     /// The same as **new2**, but boxes the given node data before storing it.
     pub fn boxed2<T>(node: T) -> Self
     where
-        T: 'static + Node,
+        T: 'static + Node<W>,
     {
         Self::boxed(node, vec![Buffer::SILENT, Buffer::SILENT])
     }

--- a/dasp_graph/src/lib.rs
+++ b/dasp_graph/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! The edges of a `dasp` graph describe the direction of audio flow through the graph. That is,
 //! the edge *a -> b* describes that the audio output of node *a* will be used as an input to node *b*.
-//! Edges can also contain weights of arbitrary type, which are provided to destination nodes and can
+//! Edges can also contain weights of any `Clone` type, which are provided to destination nodes and can
 //! allow them to distinguish between different types of connections.
 //!
 //! Once we have added our nodes and edges describing the flow of audio through our graph, we can

--- a/dasp_graph/src/lib.rs
+++ b/dasp_graph/src/lib.rs
@@ -17,9 +17,10 @@
 //! popular node implementations out of the box, each of which may be accessed by enabling [their
 //! associated features](./index.html#optional-features).
 //!
-//! The edges of a `dasp` graph are empty and simply describe the direction of audio flow
-//! through the graph. That is, the edge *a -> b* describes that the audio output of node *a* will
-//! be used as an input to node *b*.
+//! The edges of a `dasp` graph describe the direction of audio flow through the graph. That is,
+//! the edge *a -> b* describes that the audio output of node *a* will be used as an input to node *b*.
+//! Edges can also contain weights of arbitrary type, which are provided to destination nodes and can
+//! allow them to distinguish between different types of connections.
 //!
 //! Once we have added our nodes and edges describing the flow of audio through our graph, we can
 //! repeatedly process and retrieve audio from it using the [`Processor`](./struct.Processor.html)
@@ -120,8 +121,8 @@
 //!
 //! ### no_std
 //!
-//! *TODO: Adding support for `no_std` is pending the addition of support for `no_std` in petgraph.
-//! See https://github.com/petgraph/petgraph/pull/238.
+//! **TODO:** Adding support for `no_std` is pending the addition of support for `no_std` in petgraph.
+//! [See this pull request](https://github.com/petgraph/petgraph/pull/238).
 
 pub use buffer::Buffer;
 pub use node::{Input, Node};
@@ -303,13 +304,13 @@ impl<W> NodeData<BoxedNode<W>> {
 /// connected to the inputs of the given `node`. This ensures that all inputs of each node are
 /// visited before the node itself.
 ///
-/// The `Node::process` method is called on each node as they are visited in the traversal.
+/// The [`Node::process`] method is called on each node as they are visited in the traversal.
 ///
 /// Upon returning, the buffers of each visited node will contain the audio processed by their
 /// respective nodes.
 ///
 /// Supports all graphs that implement the necessary petgraph traits and whose nodes are of
-/// type `NodeData<T>` where `T` implements the `Node` trait.
+/// type `NodeData<T>` where `T` implements the [`Node`] trait.
 ///
 /// **Panics** if there is no node for the given index.
 pub fn process<G, T>(processor: &mut Processor<G>, graph: &mut G, node: G::NodeId)

--- a/dasp_graph/src/node/boxed.rs
+++ b/dasp_graph/src/node/boxed.rs
@@ -6,7 +6,7 @@ use core::ops::{Deref, DerefMut};
 ///
 /// Provides the necessary `Sized` implementation to allow for compatibility with the graph process
 /// function.
-pub struct BoxedNode(pub Box<dyn Node>);
+pub struct BoxedNode<W = ()>(pub Box<dyn Node<W>>);
 
 /// A wrapper around a `Box<dyn Node>`.
 ///
@@ -16,107 +16,107 @@ pub struct BoxedNode(pub Box<dyn Node>);
 /// Useful when the ability to send nodes from one thread to another is required. E.g. this is
 /// common when initialising nodes or the audio graph itself on one thread before sending them to
 /// the audio thread.
-pub struct BoxedNodeSend(pub Box<dyn Node + Send>);
+pub struct BoxedNodeSend<W = ()>(pub Box<dyn Node<W> + Send>);
 
-impl BoxedNode {
+impl<W> BoxedNode<W> {
     /// Create a new `BoxedNode` around the given `node`.
     ///
     /// This is short-hand for `BoxedNode::from(Box::new(node))`.
     pub fn new<T>(node: T) -> Self
     where
-        T: 'static + Node,
+        T: 'static + Node<W>,
     {
         Self::from(Box::new(node))
     }
 }
 
-impl BoxedNodeSend {
+impl<W> BoxedNodeSend<W> {
     /// Create a new `BoxedNode` around the given `node`.
     ///
     /// This is short-hand for `BoxedNode::from(Box::new(node))`.
     pub fn new<T>(node: T) -> Self
     where
-        T: 'static + Node + Send,
+        T: 'static + Node<W> + Send,
     {
         Self::from(Box::new(node))
     }
 }
 
-impl Node for BoxedNode {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for BoxedNode<W> {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         self.0.process(inputs, output)
     }
 }
 
-impl Node for BoxedNodeSend {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for BoxedNodeSend<W> {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         self.0.process(inputs, output)
     }
 }
 
-impl<T> From<Box<T>> for BoxedNode
+impl<T, W> From<Box<T>> for BoxedNode<W>
 where
-    T: 'static + Node,
+    T: 'static + Node<W>,
 {
     fn from(n: Box<T>) -> Self {
-        BoxedNode(n as Box<dyn Node>)
+        BoxedNode(n as Box<dyn Node<W>>)
     }
 }
 
-impl<T> From<Box<T>> for BoxedNodeSend
+impl<T, W> From<Box<T>> for BoxedNodeSend<W>
 where
-    T: 'static + Node + Send,
+    T: 'static + Node<W> + Send,
 {
     fn from(n: Box<T>) -> Self {
-        BoxedNodeSend(n as Box<dyn Node + Send>)
+        BoxedNodeSend(n as Box<dyn Node<W> + Send>)
     }
 }
 
-impl Into<Box<dyn Node>> for BoxedNode {
-    fn into(self) -> Box<dyn Node> {
+impl<W> Into<Box<dyn Node<W>>> for BoxedNode<W> {
+    fn into(self) -> Box<dyn Node<W>> {
         self.0
     }
 }
 
-impl Into<Box<dyn Node + Send>> for BoxedNodeSend {
-    fn into(self) -> Box<dyn Node + Send> {
+impl<W> Into<Box<dyn Node<W> + Send>> for BoxedNodeSend<W> {
+    fn into(self) -> Box<dyn Node<W> + Send> {
         self.0
     }
 }
 
-impl fmt::Debug for BoxedNode {
+impl<W> fmt::Debug for BoxedNode<W> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BoxedNode").finish()
     }
 }
 
-impl fmt::Debug for BoxedNodeSend {
+impl<W> fmt::Debug for BoxedNodeSend<W> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BoxedNodeSend").finish()
     }
 }
 
-impl Deref for BoxedNode {
-    type Target = Box<dyn Node>;
+impl<W> Deref for BoxedNode<W> {
+    type Target = Box<dyn Node<W>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl Deref for BoxedNodeSend {
-    type Target = Box<dyn Node + Send>;
+impl<W> Deref for BoxedNodeSend<W> {
+    type Target = Box<dyn Node<W> + Send>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for BoxedNode {
+impl<W> DerefMut for BoxedNode<W> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl DerefMut for BoxedNodeSend {
+impl<W> DerefMut for BoxedNodeSend<W> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/dasp_graph/src/node/delay.rs
+++ b/dasp_graph/src/node/delay.rs
@@ -9,11 +9,11 @@ use dasp_ring_buffer as ring_buffer;
 #[derive(Clone, Debug, PartialEq)]
 pub struct Delay<S>(pub Vec<ring_buffer::Fixed<S>>);
 
-impl<S> Node for Delay<S>
+impl<S, W> Node<W> for Delay<S>
 where
     S: ring_buffer::SliceMut<Element = f32>,
 {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         // Retrieve the single input, ignore any others.
         let input = match inputs.get(0) {
             Some(input) => input,

--- a/dasp_graph/src/node/graph.rs
+++ b/dasp_graph/src/node/graph.rs
@@ -5,11 +5,11 @@
 use crate::{Buffer, Input, Node, NodeData, Processor};
 use core::marker::PhantomData;
 use petgraph::data::DataMapMut;
-use petgraph::visit::{Data, GraphBase, IntoNeighborsDirected, Visitable};
+use petgraph::visit::{Data, GraphBase, IntoEdgesDirected, Visitable};
 
 pub struct GraphNode<G, T>
 where
-    G: Visitable,
+    G: Visitable + Data,
 {
     pub processor: Processor<G>,
     pub graph: G,
@@ -21,8 +21,10 @@ where
 impl<G, T> Node for GraphNode<G, T>
 where
     G: Data<NodeWeight = NodeData<T>> + DataMapMut + Visitable,
-    for<'a> &'a G: GraphBase<NodeId = G::NodeId> + IntoNeighborsDirected,
-    T: Node,
+    for<'a> &'a G:
+        GraphBase<NodeId = G::NodeId> + IntoEdgesDirected + Data<EdgeWeight = G::EdgeWeight>,
+    G::EdgeWeight: Clone,
+    T: Node<G::EdgeWeight>,
 {
     fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
         let GraphNode {

--- a/dasp_graph/src/node/graph.rs
+++ b/dasp_graph/src/node/graph.rs
@@ -18,7 +18,7 @@ where
     pub node_type: PhantomData<T>,
 }
 
-impl<G, T> Node for GraphNode<G, T>
+impl<G, T, W> Node<W> for GraphNode<G, T>
 where
     G: Data<NodeWeight = NodeData<T>> + DataMapMut + Visitable,
     for<'a> &'a G:
@@ -26,7 +26,7 @@ where
     G::EdgeWeight: Clone,
     T: Node<G::EdgeWeight>,
 {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         let GraphNode {
             ref mut processor,
             ref mut graph,

--- a/dasp_graph/src/node/mod.rs
+++ b/dasp_graph/src/node/mod.rs
@@ -128,38 +128,38 @@ impl<W> fmt::Debug for Input<W> {
     }
 }
 
-impl<'a, T> Node for &'a mut T
+impl<'a, T, W> Node<W> for &'a mut T
 where
-    T: Node + ?Sized,
+    T: Node<W> + ?Sized,
 {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         (**self).process(inputs, output)
     }
 }
 
-impl<T> Node for Box<T>
+impl<T, W> Node<W> for Box<T>
 where
-    T: Node + ?Sized,
+    T: Node<W> + ?Sized,
 {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         (**self).process(inputs, output)
     }
 }
 
-impl Node for dyn Fn(&[Input], &mut [Buffer]) {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for dyn Fn(&[Input<W>], &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         (*self)(inputs, output)
     }
 }
 
-impl Node for dyn FnMut(&[Input], &mut [Buffer]) {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for dyn FnMut(&[Input<W>], &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         (*self)(inputs, output)
     }
 }
 
-impl Node for fn(&[Input], &mut [Buffer]) {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for fn(&[Input<W>], &mut [Buffer]) {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         (*self)(inputs, output)
     }
 }

--- a/dasp_graph/src/node/mod.rs
+++ b/dasp_graph/src/node/mod.rs
@@ -74,7 +74,8 @@ pub trait Node<W = ()> {
     ///
     /// `inputs` represents a list of all nodes with direct edges toward this node. Each
     /// [`Input`](./struct.Input.html) within the list can providee a reference to the output
-    /// buffers of their corresponding node.
+    /// buffers of its corresponding node, as well as the weight of the edge connecting it
+    /// to this node.
     ///
     /// The `inputs` may be ignored if the implementation is for a source node. Alternatively, if
     /// the `Node` only supports a specific number of `input`s, it is up to the user to decide how
@@ -87,9 +88,9 @@ pub trait Node<W = ()> {
 
 /// A reference to another node that is an input to the current node.
 ///
-/// *TODO: It may be useful to provide some information that can uniquely identify the input node.
-/// This could be useful to allow to distinguish between side-chained and regular inputs for
-/// example.*
+/// The edge weight from the graph is provided to support differentiating between inputs.
+/// For example, you can use an enum to identify main vs sidechain inputs, or label the edges
+/// with the source node's ID.
 pub struct Input<W = ()> {
     buffers_ptr: *const Buffer,
     buffers_len: usize,

--- a/dasp_graph/src/node/mod.rs
+++ b/dasp_graph/src/node/mod.rs
@@ -93,7 +93,7 @@ pub trait Node<W = ()> {
 pub struct Input<W = ()> {
     buffers_ptr: *const Buffer,
     buffers_len: usize,
-    pub edge_weight: W,
+    edge_weight: W,
 }
 
 impl<W> Input<W> {
@@ -114,6 +114,11 @@ impl<W> Input<W> {
         // function, we can be sure that our slice is still valid as long as the input itself is
         // alive.
         unsafe { std::slice::from_raw_parts(self.buffers_ptr, self.buffers_len) }
+    }
+
+    /// A reference to the input's edge weight.
+    pub fn edge_weight(&self) -> &W {
+        &self.edge_weight
     }
 }
 

--- a/dasp_graph/src/node/mod.rs
+++ b/dasp_graph/src/node/mod.rs
@@ -94,7 +94,7 @@ pub trait Node<W = ()> {
 pub struct Input<W = ()> {
     buffers_ptr: *const Buffer,
     buffers_len: usize,
-    edge_weight: W,
+    pub edge_weight: W,
 }
 
 impl<W> Input<W> {
@@ -115,11 +115,6 @@ impl<W> Input<W> {
         // function, we can be sure that our slice is still valid as long as the input itself is
         // alive.
         unsafe { std::slice::from_raw_parts(self.buffers_ptr, self.buffers_len) }
-    }
-
-    /// A reference to the input's edge weight.
-    pub fn edge_weight(&self) -> &W {
-        &self.edge_weight
     }
 }
 

--- a/dasp_graph/src/node/pass.rs
+++ b/dasp_graph/src/node/pass.rs
@@ -10,8 +10,8 @@ use crate::{Buffer, Input, Node};
 #[derive(Clone, Debug, PartialEq)]
 pub struct Pass;
 
-impl Node for Pass {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for Pass {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         let input = match inputs.get(0) {
             None => return,
             Some(input) => input,

--- a/dasp_graph/src/node/signal.rs
+++ b/dasp_graph/src/node/signal.rs
@@ -2,11 +2,11 @@ use crate::{Buffer, Input, Node};
 use dasp_frame::Frame;
 use dasp_signal::Signal;
 
-impl<F> Node for dyn Signal<Frame = F>
+impl<F, W> Node<W> for dyn Signal<Frame = F>
 where
     F: Frame<Sample = f32>,
 {
-    fn process(&mut self, _inputs: &[Input], output: &mut [Buffer]) {
+    fn process(&mut self, _inputs: &[Input<W>], output: &mut [Buffer]) {
         let channels = std::cmp::min(F::CHANNELS, output.len());
         for ix in 0..Buffer::LEN {
             let frame = self.next();

--- a/dasp_graph/src/node/sum.rs
+++ b/dasp_graph/src/node/sum.rs
@@ -22,8 +22,8 @@ pub struct Sum;
 #[derive(Clone, Debug, PartialEq)]
 pub struct SumBuffers;
 
-impl Node for Sum {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for Sum {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         // Fill the output with silence.
         for out_buffer in output.iter_mut() {
             out_buffer.silence();
@@ -40,8 +40,8 @@ impl Node for Sum {
     }
 }
 
-impl Node for SumBuffers {
-    fn process(&mut self, inputs: &[Input], output: &mut [Buffer]) {
+impl<W> Node<W> for SumBuffers {
+    fn process(&mut self, inputs: &[Input<W>], output: &mut [Buffer]) {
         // Get the first output buffer.
         let mut out_buffers = output.iter_mut();
         let out_buffer_first = match out_buffers.next() {


### PR DESCRIPTION
This PR makes `Node` and `Input` generic by edge weight, and passes the edge weight to `process` on each `Input`, resolving a TODO in the docs.

This is only implemented for weights that implement `Clone`, because I could not figure out a good way to store a reference to the weight in the `Input` structs due to how the processor's `inputs` field is reused. But I think this will be sufficient for the majority of use cases, where we usually just need to distinguish inputs by simple types.

I think this change is backwards compatible, because the `W` type parameter used to refer to the weight defaults to `()`, and I didn't have to make any changes to my (small) project after switching to this branch.

Documentation is also updated.