### PR TITLE
Remove nightly requirement for no_std

### DIFF
--- a/dasp_sample/src/lib.rs
+++ b/dasp_sample/src/lib.rs
@@ -5,7 +5,6 @@
 //! are based.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/dasp_sample/src/ops.rs
+++ b/dasp_sample/src/ops.rs
@@ -4,7 +4,11 @@ pub mod f32 {
 
     #[cfg(not(feature = "std"))]
     pub fn sqrt(x: f32) -> f32 {
-        unsafe { core::intrinsics::sqrtf32(x) }
+        if x >= 0.0 {
+            f32::from_bits((x.to_bits() + 0x3f80_0000) >> 1)
+        } else {
+            f32::NAN
+        }
     }
     #[cfg(feature = "std")]
     pub fn sqrt(x: f32) -> f32 {
@@ -18,7 +22,11 @@ pub mod f64 {
 
     #[cfg(not(feature = "std"))]
     pub fn sqrt(x: f64) -> f64 {
-        unsafe { core::intrinsics::sqrtf64(x) }
+        if x >= 0.0 {
+            f64::from_bits((x.to_bits() + 0x3f80_0000) >> 1)
+        } else {
+            f64::NAN
+        }
     }
     #[cfg(feature = "std")]
     pub fn sqrt(x: f64) -> f64 {


### PR DESCRIPTION
I think it is overkill that all `dasp` libraries require `Nightly` just because there is no `sqrt()` function implementation for floating point types in `no_std` environment.
In my case, I just wanted to use the `Frame` type, but compiler requires nightly.
I did the same implementation to the sqrt() method as `micromath` or this one that it was based on.
https://github.com/tarcieri/micromath/blob/6de9df6943b6f06c087ab43ddc3523a379e00369/src/float/sqrt.rs#L13
https://bits.stephan-brumme.com/squareRoot.html
Adding micro_math to dependencies is a good idea, but if you think it is overkill, how about what I wrote?
What I wrote is just a suggestion, I believe the issue is that `dasp` requires `Nightly` if you try to use it in `no_std`.