### PR TITLE
Correct Frames trait Documentation

### DIFF
--- a/dasp_frame/src/lib.rs
+++ b/dasp_frame/src/lib.rs
@@ -153,7 +153,7 @@ pub trait Frame: Copy + Clone + PartialEq {
         F: Frame<NumChannels = Self::NumChannels>,
         M: FnMut(Self::Sample, O::Sample) -> F::Sample;
 
-    /// Converts the frame type to the equivalent signal in its associated `Float`ing point format.
+    /// Converts the frame type to the equivalent signal in its associated `Signed` format.
     ///
     /// # Example
     ///
@@ -168,7 +168,7 @@ pub trait Frame: Copy + Clone + PartialEq {
     /// ```
     fn to_signed_frame(self) -> Self::Signed;
 
-    /// Converts the frame type to the equivalent signal in its associated `Signed` format.
+    /// Converts the frame type to the equivalent signal in its associated `Float`ing point format.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Documentation for to_signed_frame and to_float_frame trait methods was in parts swapped. Very small change