### PR TITLE
fix: improve sqrt implementations for f32 and f64 without std

### DIFF
--- a/dasp_rms/src/lib.rs
+++ b/dasp_rms/src/lib.rs
@@ -117,9 +117,17 @@ where
     /// fn main() {
     ///     let window = ring_buffer::Fixed::from([[0.0]; 4]);
     ///     let mut rms = Rms::new(window);
+    ///
     ///     assert_eq!(rms.next([1.0]), [0.5]);
-    ///     assert_eq!(rms.next([-1.0]), [0.7071067811865476]);
-    ///     assert_eq!(rms.next([1.0]), [0.8660254037844386]);
+    ///
+    ///     let result = rms.next([-1.0])[0];
+    ///     assert!(f64::abs(result - 0.7071067811865476) < 0.000001,
+    ///             "Expected ~0.7071067811865476, got {}", result);
+    ///
+    ///     let result = rms.next([1.0])[0];
+    ///     assert!(f64::abs(result - 0.8660254037844386) < 0.000001,
+    ///             "Expected ~0.8660254037844386, got {}", result);
+    ///
     ///     assert_eq!(rms.next([-1.0]), [1.0]);
     /// }
     /// ```

--- a/dasp_sample/src/ops.rs
+++ b/dasp_sample/src/ops.rs
@@ -1,34 +1,68 @@
 pub mod f32 {
-    #[allow(unused_imports)]
-    use core;
-
+    /// Newton-Raphson square root implementation for f32.
+    /// Uses bit manipulation for initial guess, then 3 iterations for ~6-7 decimal places.
+    /// Accuracy: ~6-7 decimal places
     #[cfg(not(feature = "std"))]
     pub fn sqrt(x: f32) -> f32 {
-        if x >= 0.0 {
-            f32::from_bits((x.to_bits() + 0x3f80_0000) >> 1)
-        } else {
-            f32::NAN
+        if x < 0.0 {
+            return f32::NAN;
         }
+        if x == 0.0 {
+            return x; // preserves +0.0 and -0.0
+        }
+
+        // Initial guess from bit manipulation: halve exponent, shift mantissa
+        let bits = x.to_bits();
+        let exp = (bits >> 23) & 0xff;
+        let mant = bits & 0x7fffff;
+
+        let unbiased = exp as i32 - 127;
+        let sqrt_exp = (unbiased / 2 + 127) as u32;
+        let guess_bits = (sqrt_exp << 23) | (mant >> 1);
+        let mut guess = f32::from_bits(guess_bits);
+
+        for _ in 0..3 {
+            guess = 0.5 * (guess + x / guess);
+        }
+        guess
     }
     #[cfg(feature = "std")]
+    #[inline]
     pub fn sqrt(x: f32) -> f32 {
         x.sqrt()
     }
 }
 
 pub mod f64 {
-    #[allow(unused_imports)]
-    use core;
-
+    /// Newton-Raphson square root implementation for f64.
+    /// Uses bit manipulation for initial guess, then 4 iterations for ~14-15 decimal places.
+    /// Accuracy: ~14-15 decimal places
     #[cfg(not(feature = "std"))]
     pub fn sqrt(x: f64) -> f64 {
-        if x >= 0.0 {
-            f64::from_bits((x.to_bits() + 0x3f80_0000) >> 1)
-        } else {
-            f64::NAN
+        if x < 0.0 {
+            return f64::NAN;
         }
+        if x == 0.0 {
+            return x; // preserves +0.0 and -0.0
+        }
+
+        // Initial guess from bit manipulation: halve exponent, shift mantissa
+        let bits = x.to_bits();
+        let exp = (bits >> 52) & 0x7ff;
+        let mant = bits & 0x000f_ffff_ffff_ffff;
+
+        let unbiased = exp as i32 - 1023;
+        let sqrt_exp = (unbiased / 2 + 1023) as u64;
+        let guess_bits = (sqrt_exp << 52) | (mant >> 1);
+        let mut guess = f64::from_bits(guess_bits);
+
+        for _ in 0..4 {
+            guess = 0.5 * (guess + x / guess);
+        }
+        guess
     }
     #[cfg(feature = "std")]
+    #[inline]
     pub fn sqrt(x: f64) -> f64 {
         x.sqrt()
     }

--- a/dasp_signal/src/rms.rs
+++ b/dasp_signal/src/rms.rs
@@ -33,10 +33,18 @@ pub trait SignalRms: Signal {
     ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let ring_buffer = ring_buffer::Fixed::from([[0.0]; 2]);
     ///     let mut rms_signal = signal.rms(ring_buffer);
-    ///     assert_eq!(
-    ///         [rms_signal.next(), rms_signal.next(), rms_signal.next()],
-    ///         [[0.6363961030678927], [0.8514693182963201], [0.7071067811865476]]
-    ///     );
+    ///
+    ///     let result = rms_signal.next()[0];
+    ///     assert!(f64::abs(result - 0.6363961030678927) < 0.000001,
+    ///             "Expected ~0.6363961030678927, got {}", result);
+    ///
+    ///     let result = rms_signal.next()[0];
+    ///     assert!(f64::abs(result - 0.8514693182963201) < 0.000001,
+    ///             "Expected ~0.8514693182963201, got {}", result);
+    ///
+    ///     let result = rms_signal.next()[0];
+    ///     assert!(f64::abs(result - 0.7071067811865476) < 0.000001,
+    ///             "Expected ~0.7071067811865476, got {}", result);
     /// }
     /// ```
     ///


### PR DESCRIPTION
The CI got broken when the `no_std` implementations for `f32` and `f64` were custom-rolled instead of using core intrinsics in this commit: https://github.com/RustAudio/dasp/commit/cd8d8931ba6ff589d5c6334641641c116e09fe58. Beyond breaking the CI, RMS values are way off.

## Problem

The current implementation:
- takes an initial guess without refinement
- uses an incorrect bias for `f64`
- causing wildly inaccurate values:

```
failures:

---- dasp_rms/src/lib.rs - Rms<F,S>::next (line 113) stdout ----
Test executable failed (exit status: 101).

stderr:

thread 'main' (6233708) panicked at dasp_rms/src/lib.rs:10:5:
assertion `left == right` failed
  left: [5.593755989478844e-155]
 right: [0.5]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


---- dasp_rms/src/lib.rs - Rms<F,S>::current (line 172) stdout ----
Test executable failed (exit status: 101).

stderr:

thread 'main' (6233709) panicked at dasp_rms/src/lib.rs:10:5:
assertion `left == right` failed
  left: [2.631772124e-315]
 right: [0.0]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


---- dasp_rms/src/lib.rs - Rms<F,S>::reset (line 62) stdout ----
Test executable failed (exit status: 101).

stderr:

thread 'main' (6233711) panicked at dasp_rms/src/lib.rs:13:5:
assertion `left == right` failed
  left: [2.631772124e-315]
 right: [0.0]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


---- dasp_signal/src/rms.rs - rms::SignalRms::rms (line 26) stdout ----
Test executable failed (exit status: 101).

stderr:

thread 'main' (6236011) panicked at dasp_signal/src/rms.rs:13:5:
assertion `left == right` failed
  left: [[6.749798802814877e-155], [9.136468277877633e-155], [7.458341613357585e-155]]
 right: [[0.6363961030678927], [0.8514693182963201], [0.7071067811865476]]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Solution

This PR improves the initial guess and uses Newton-Raphson refinement to improve the accuracy to >6 decimal places.