### PR TITLE
feat: re-export petgraph, since it is part of the public API

### DIFF
--- a/dasp_graph/src/lib.rs
+++ b/dasp_graph/src/lib.rs
@@ -125,6 +125,11 @@
 
 pub use buffer::Buffer;
 pub use node::{Input, Node};
+
+// Petgraph's traits appear in the public API of dasp_graph, so re-exporting
+// allows the user to be guaranteed that they are using the correct version of
+// petgraph, avoiding unintuitive errors like in #176.
+pub use petgraph;
 use petgraph::data::{DataMap, DataMapMut};
 use petgraph::visit::{
     Data, DfsPostOrder, GraphBase, IntoNeighborsDirected, NodeCount, NodeIndexable, Reversed,
@@ -147,9 +152,8 @@ pub mod node;
 /// # Example
 ///
 /// ```
-/// use dasp_graph::{Node, NodeData};
+/// use dasp_graph::{petgraph, Node, NodeData};
 /// # use dasp_graph::{Buffer, Input};
-/// use petgraph;
 /// #
 /// # // The node type. (Hint: Use existing node impls by enabling their associated features).
 /// # struct MyNode;

--- a/dasp_graph/tests/graph_send.rs
+++ b/dasp_graph/tests/graph_send.rs
@@ -5,8 +5,10 @@
 #![cfg(feature = "node-boxed")]
 #![allow(unreachable_code, unused_variables)]
 
-use dasp_graph::{BoxedNodeSend, NodeData};
-use petgraph::visit::GraphBase;
+use dasp_graph::{
+    petgraph::{self, visit::GraphBase},
+    BoxedNodeSend, NodeData,
+};
 
 #[test]
 #[should_panic]

--- a/dasp_graph/tests/graph_types.rs
+++ b/dasp_graph/tests/graph_types.rs
@@ -5,8 +5,10 @@
 #![cfg(feature = "node-boxed")]
 #![allow(unreachable_code, unused_variables)]
 
-use dasp_graph::{BoxedNode, NodeData};
-use petgraph::visit::GraphBase;
+use dasp_graph::{
+    petgraph::{self, visit::GraphBase},
+    BoxedNode, NodeData,
+};
 
 #[test]
 #[should_panic]

--- a/dasp_graph/tests/sum.rs
+++ b/dasp_graph/tests/sum.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "node-boxed", feature = "node-sum"))]
 
-use dasp_graph::{node, Buffer, Input, Node, NodeData};
+use dasp_graph::{node, petgraph, Buffer, Input, Node, NodeData};
 
 type BoxedNode = dasp_graph::BoxedNode;
 


### PR DESCRIPTION
Original issue was actually intended behavior, though very unintuitive. I have added a re-export of `petgraph` to make sure the user is using the same version as the one in the public API of `dasp_graph`. See my comment on #176.

# Caveats
By re-exporting `petgraph` we are effectively committing to having the entirety of `petgraph` as part of the API. An alternative approach would be to write our own traits for our API, to decouple from petgraph, and only use petgraph internally.

