### PR TITLE
Add a `len` field to track the size of the window.

### DIFF
--- a/dasp_signal/src/window/mod.rs
+++ b/dasp_signal/src/window/mod.rs
@@ -31,6 +31,8 @@ where
 {
     /// Yields phase stepped at a constant rate to be passed to the window function `W`.
     pub phase: Phase<ConstHz>,
+    /// Size of the window
+    pub len: usize,
     marker: PhantomData<(F, W)>,
 }
 
@@ -87,6 +89,7 @@ where
     pub fn new(len: usize) -> Self {
         let step = crate::rate(len as f64 - 1.0).const_hz(1.0);
         Window {
+            len,
             phase: crate::phase(step),
             marker: PhantomData,
         }
@@ -122,6 +125,12 @@ where
     type Item = F;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // make sure we didn't produce items indefinitely
+        if self.len == 0 {
+            return None;
+        }
+
+        self.len -= 1;
         let v = W::window(self.phase.next_phase());
         let v_f: <F::Sample as Sample>::Float = v.to_sample();
         Some(F::from_fn(|_| v_f.to_sample::<F::Sample>()))

--- a/dasp_signal/tests/window.rs
+++ b/dasp_signal/tests/window.rs
@@ -49,3 +49,25 @@ fn test_window_size() {
         .collect();
     assert_eq!(windows.len(), 3);
 }
+
+#[cfg(feature = "window-hann")]
+#[test]
+fn test_window_iterator() {
+    let v = [1f32; 16];
+    let windower = Windower::hann(&v, 8, 4);
+
+    let mut window_count = 0;
+    let mut sample_count = 0;
+
+    for window in windower {
+        window_count += 1;
+        for sample in window {
+            sample_count += 1
+        }
+    }
+
+    // || - first window, {} - second window, [] - third window, s - samples
+    // | s, s, s, s, { s, s, s, s | [ s, s, s, s, } s, s, s, s, ]
+    assert_eq!(window_count, 3);
+    assert_eq!(sample_count, 3 * 8);
+}


### PR DESCRIPTION
Currently, the iterator of the window produces samples indefinitely. This is not intuitive at first glance. Also, if I just want to work with samples in a plain `for each`, I need to remember to call `take` a fixed number of samples first; otherwise, it will loop indefinitely.