### PR TITLE
Add equilibrium-padded interpolator constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added `equilibrium_padded` constructors for `Floor`, `Linear`, and `Sinc`
+  interpolators.
 - Renamed `window-hanning` to `window-hann`
 - Made `IntoInterleavedSamples` and `IntoInterleavedSamplesIterator` stop
   yielding samples when the underlying signal gets exhausted. This is a breaking

--- a/dasp_interpolate/src/floor.rs
+++ b/dasp_interpolate/src/floor.rs
@@ -29,6 +29,27 @@ impl<F> Floor<F> {
     pub fn new(left: F) -> Floor<F> {
         Floor { left: left }
     }
+
+    /// Create a new Floor Interpolator padded with equilibrium.
+    ///
+    /// ### Required Features
+    ///
+    /// - When using `dasp_interpolate`, this item requires the **floor** feature to be enabled.
+    /// - When using `dasp`, this item requires the **interpolate-floor** feature to be enabled.
+    ///
+    /// ```
+    /// use dasp_interpolate::floor::Floor;
+    ///
+    /// let interp = Floor::<f32>::equilibrium_padded();
+    /// ```
+    pub fn equilibrium_padded() -> Floor<F>
+    where
+        F: Frame,
+    {
+        Floor {
+            left: F::EQUILIBRIUM,
+        }
+    }
 }
 
 impl<F> Interpolator for Floor<F>

--- a/dasp_interpolate/src/linear.rs
+++ b/dasp_interpolate/src/linear.rs
@@ -34,6 +34,30 @@ impl<F> Linear<F> {
             right: right,
         }
     }
+
+    /// Create a new Linear Interpolator padded with equilibrium.
+    ///
+    /// Both the left and right frames are initialized to `Frame::EQUILIBRIUM`.
+    ///
+    /// ### Required Features
+    ///
+    /// - When using `dasp_interpolate`, this item requires the **linear** feature to be enabled.
+    /// - When using `dasp`, this item requires the **interpolate-linear** feature to be enabled.
+    ///
+    /// ```
+    /// use dasp_interpolate::linear::Linear;
+    ///
+    /// let interp = Linear::<f32>::equilibrium_padded();
+    /// ```
+    pub fn equilibrium_padded() -> Linear<F>
+    where
+        F: Frame,
+    {
+        Linear {
+            left: F::EQUILIBRIUM,
+            right: F::EQUILIBRIUM,
+        }
+    }
 }
 
 impl<F> Interpolator for Linear<F>

--- a/dasp_interpolate/src/sinc/mod.rs
+++ b/dasp_interpolate/src/sinc/mod.rs
@@ -54,6 +54,39 @@ impl<S> Sinc<S> {
         }
     }
 
+    /// Create a new **Sinc** interpolator with the given ring buffer padded with equilibrium.
+    ///
+    /// The given ring buffer should have a length twice that of the desired sinc interpolation
+    /// `depth`.
+    ///
+    /// The initial contents of the ring_buffer are replaced with `Frame::EQUILIBRIUM`.
+    ///
+    /// **panic!**s if the given ring buffer's length is not a multiple of `2`.
+    ///
+    /// ### Required Features
+    ///
+    /// - When using `dasp_interpolate`, this item requires the **sinc** feature to be enabled.
+    /// - When using `dasp`, this item requires the **interpolate-sinc** feature to be enabled.
+    ///
+    /// ```
+    /// use dasp_interpolate::sinc::Sinc;
+    /// use dasp_ring_buffer as ring_buffer;
+    ///
+    /// let frames = ring_buffer::Fixed::from([1.0; 8]);
+    /// let interp = Sinc::equilibrium_padded(frames);
+    /// ```
+    pub fn equilibrium_padded(mut frames: ring_buffer::Fixed<S>) -> Self
+    where
+        S: ring_buffer::SliceMut,
+        S::Element: Frame,
+    {
+        assert!(frames.len() % 2 == 0);
+        for frame in frames.iter_mut() {
+            *frame = <S::Element as Frame>::EQUILIBRIUM;
+        }
+        Sinc { frames, idx: 0 }
+    }
+
     fn depth(&self) -> usize
     where
         S: ring_buffer::Slice,

--- a/dasp_signal/tests/interpolate.rs
+++ b/dasp_signal/tests/interpolate.rs
@@ -1,6 +1,6 @@
 //! Tests for the `Converter` and `Interpolator` traits
 
-use dasp_interpolate::{floor::Floor, linear::Linear, sinc::Sinc};
+use dasp_interpolate::{floor::Floor, linear::Linear, sinc::Sinc, Interpolator};
 use dasp_ring_buffer as ring_buffer;
 use dasp_signal::{self as signal, interpolate::Converter, Signal};
 
@@ -24,6 +24,17 @@ fn test_floor_converter() {
 }
 
 #[test]
+fn test_floor_equilibrium_padded() {
+    let mut interp = Floor::<f64>::equilibrium_padded();
+
+    assert_eq!(interp.interpolate(0.0), 0.0);
+    assert_eq!(interp.interpolate(0.5), 0.0);
+
+    interp.next_source_frame(1.0);
+    assert_eq!(interp.interpolate(0.5), 1.0);
+}
+
+#[test]
 fn test_linear_converter() {
     let frames: [f64; 3] = [0.0, 1.0, 2.0];
     let mut source = signal::from_iter(frames.iter().cloned());
@@ -40,6 +51,21 @@ fn test_linear_converter() {
     // There's nothing else here to interpolate toward, but we do want to ensure that we're
     // emitting the correct number of frames.
     assert_eq!(conv.next(), 1.0);
+}
+
+#[test]
+fn test_linear_equilibrium_padded() {
+    let mut interp = Linear::<f64>::equilibrium_padded();
+
+    assert_eq!(interp.interpolate(0.0), 0.0);
+    assert_eq!(interp.interpolate(0.5), 0.0);
+
+    interp.next_source_frame(1.0);
+    assert_eq!(interp.interpolate(0.0), 0.0);
+    assert_eq!(interp.interpolate(0.5), 0.5);
+
+    interp.next_source_frame(2.0);
+    assert_eq!(interp.interpolate(0.5), 1.5);
 }
 
 #[test]
@@ -70,4 +96,17 @@ fn test_sinc() {
         resampled.until_exhausted().find(|sample| sample.is_nan()),
         None
     );
+}
+
+#[test]
+fn test_sinc_equilibrium_padded_clears_supplied_buffer() {
+    let frames = ring_buffer::Fixed::from(vec![1.0_f64; 50]);
+    let mut interp = Sinc::equilibrium_padded(frames);
+
+    assert_eq!(interp.interpolate(0.0), 0.0);
+    assert_eq!(interp.interpolate(0.5), 0.0);
+
+    interp.next_source_frame(1.0);
+    let sample = interp.interpolate(0.0);
+    assert!(sample.is_finite());
 }


### PR DESCRIPTION
Closes #121.

## Summary
Adds `equilibrium_padded` constructors for `Floor`, `Linear`, and `Sinc` interpolators.

`Floor` and `Linear` initialize their interpolation history with `Frame::EQUILIBRIUM`. `Sinc` clears the supplied ring buffer to `Frame::EQUILIBRIUM` before use, preserving the existing `Sinc::new` behavior for callers that intentionally provide custom padding.

## Validation
Ran formatting and workspace tests locally, including `dasp_interpolate`, `dasp_signal`, and `cargo test --locked --workspace --all-targets`.

## Sonic smoke
A local startup-transient A/B render confirmed the behavior: dirty `Sinc::new` had peak `1.10` in the first 128 samples, while `Sinc::equilibrium_padded` had peak `0.0` and matched the zero-buffer baseline with max abs diff `0.0`.
